### PR TITLE
dev: adapt to Bilibili extractor API changes

### DIFF
--- a/app/src/main/java/us/shandian/giga/util/Utility.java
+++ b/app/src/main/java/us/shandian/giga/util/Utility.java
@@ -42,6 +42,7 @@ import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
 import us.shandian.giga.get.DownloadMission;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
 
+import static org.schabi.newpipe.extractor.services.bilibili.BilibiliService.WWW_REFERER;
 import static org.schabi.newpipe.streams.io.StoredDirectoryHelper.findFileSAFHelper;
 
 public class Utility {
@@ -327,7 +328,7 @@ public class Utility {
     public static void setRequestPropertyIfDownloadingBilibili(String url, HttpURLConnection conn) throws IOException {
         if(BilibiliService.isBiliBiliDownloadUrl(url)){
             // from header map set RequestProperty
-            Map<String, List<String>> headerMap = BilibiliService.getDownloadHeaders();
+            Map<String, List<String>> headerMap = BilibiliService.getUserAgentHeaders(WWW_REFERER);
             for (Map.Entry<String, List<String>> entry : headerMap.entrySet()) {
                 String key = entry.getKey();
                 List<String> value = entry.getValue();


### PR DESCRIPTION
The `BilibiliService` in the extractor has been updated. This commit adapts the downloader and utility classes to use this new method.

**Other changes:**

- `DownloaderImpl`: Allow custom `User-Agent` and `Cookie` headers to override the defaults.
- `DownloaderImpl`: Ensure POST requests have a non-null request body.
- `DownloaderImpl`: Remove unused exception declarations from `getContentLength`.