### PR TITLE
Review issue#1198 

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
+++ b/app/src/main/java/org/schabi/newpipe/streams/SrtFromTtmlWriter.java
@@ -81,14 +81,8 @@ public class SrtFromTtmlWriter {
         for (final Element paragraph : paragraphList) {
             text.setLength(0);
 
-            for (final Node children : paragraph.childNodes()) {
-                if (children instanceof TextNode) {
-                    text.append(((TextNode) children).text());
-                } else if (children instanceof Element
-                        && ((Element) children).tagName().equalsIgnoreCase("br")) {
-                    text.append(NEW_LINE);
-                }
-            }
+            // Recursively extract text from all child nodes
+            extractText(paragraph, text);
 
             if (ignoreEmptyFrames && text.length() < 1) {
                 continue;
@@ -98,6 +92,27 @@ public class SrtFromTtmlWriter {
             final String end = getTimestamp(paragraph, "end");
 
             writeFrame(begin, end, text);
+        }
+    }
+
+    // Recursive method to extract text from all nodes
+    // - This method processes TextNode and <br> tags, recursively
+    //   extracting text from nested tags.
+    //   For example: extract text from nested <span> tags
+    // - Appends newlines for <br> tags.
+    private void extractText(final Node node, final StringBuilder text) {
+        if (node instanceof TextNode) {
+            text.append(((TextNode) node).text());
+        } else if (node instanceof Element) {
+            Element element = (Element) node;
+            // <br> is a self-closing HTML tag used to insert a line break.
+            if (element.tagName().equalsIgnoreCase("br")) {
+                text.append(NEW_LINE);  // Add a newline for <br> tags
+            }
+        }
+        // Recursively process child nodes
+        for (final Node child : node.childNodes()) {
+            extractText(child, text);
         }
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/util/StateSaver.java
+++ b/app/src/main/java/org/schabi/newpipe/util/StateSaver.java
@@ -30,6 +30,7 @@ import androidx.annotation.Nullable;
 
 import org.schabi.newpipe.BuildConfig;
 import org.schabi.newpipe.MainActivity;
+import org.schabi.newpipe.extractor.utils.SubtitleDeduplicator;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -69,6 +70,8 @@ public final class StateSaver {
         if (TextUtils.isEmpty(cacheDirPath)) {
             cacheDirPath = context.getCacheDir().getAbsolutePath();
         }
+
+        SubtitleDeduplicator.setCacheDirPathNotDefault(cacheDirPath);
     }
 
     /**


### PR DESCRIPTION
1. commit id: 4731f2639598aa95f4acc4d67f6e81e99c695962
This commit fixes missing subtitle text in manually downloaded *.SRT files, and it is independent of the duplicated subtitle issue(https://github.com/InfinityLoop1308/PipePipe/issues/1198).
#### Detailed Explanation:
- **Problem**: Previously, the `.SRT` files generated from TTML subtitles only included timestamp information and sequence numbers, but did not include the actual subtitle text content. Here is an BUG example from YouTube video https://www.youtube.com/watch?v=lUDPjyfmJrs (some contents of its manually downloaded *.srt file):
```
0
00:00:01,785 --> 00:00:01,952


1
00:00:01,785 --> 00:00:01,952


2
00:00:01,785 --> 00:00:03,020


3
00:00:01,785 --> 00:00:03,020


4
00:00:01,952 --> 00:00:02,086


5
00:00:01,952 --> 00:00:02,086
```

- **Solution**: Introduced a recursive `extractText()` method in `SrtFromTtmlWriter.java` to process all child nodes, extracting text from `TextNode` elements and handling nested tags. New *.SRT output:
    ```
    0
    00:00:01,785 --> 00:00:01,952
    haai chuumoku

    1
    00:00:01,785 --> 00:00:01,952
    haai chuumoku

    2
    00:00:01,785 --> 00:00:03,020
    Attention, please

    3
    00:00:01,785 --> 00:00:03,020
    Attention, please

    4
    00:00:01,952 --> 00:00:02,086
    haai chuumoku

    5
    00:00:01,952 --> 00:00:02,086
    haai chuumoku
    ```
  - **Note**: the content of *.srt is extracted from TTML file(with nested `<span>` tags):
```
  <p begin="00:00:01.785" end="00:00:01.952" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​ha</span>
  <span style="s5">ai chuumoku ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.785" end="00:00:01.952" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​ha</span>
  <span style="s5">ai chuumoku ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.785" end="00:00:03.020" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​Attention, please ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.785" end="00:00:03.020" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​Attention, please ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.952" end="00:00:02.086" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​haa</span>
  <span style="s5">i chuumoku ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.952" end="00:00:02.086" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​haa</span>
  <span style="s5">i chuumoku ​</span>
  <span style="s3"></span>
  </p>

```
  - The output contains duplicated segments (6 SRT entries from 6 TTML paragraphs) due to redundant `<p>` elements in the input TTML. Deduplication is handled separately by `SubtitleDeduplicator` if integrated, and another commit will introduce it.

2. commit id: 4014e44bad49c714492277949feb349f081e57c6
    PipePipeExtractor repository.
**New Feature**: Added utility functions for YouTube URL parameter extraction (independent of #1198).
- These parameters include videoid, language and Auto-translate language. 
- Testing: Verify with URL https://www.youtube.com/api/timedtext?v=lUDPjyfmJrs&lang=en&tlang=zh-CN:
  - `extractVideoId` should return "lUDPjyfmJrs".
  - `extractLanguageCode` should return "en".
  - `extractTranslationCode` should return "zh-CN".

3. Commit ID: 9d4a3e4afbbabdf004a4bf60313f384c04c58027
 PipePipeExtractor repository.
 This commit fixes duplicated subtitle issue (https://github.com/InfinityLoop1308/PipePipe/issues/1198)

- **Cache File Details**:
  - Deduplicated subtitles are stored in `/storage/emulated/0/Android/data/InfinityLoop1309.NewPipeEnhanced.debug/cache/subtitle_cache` or `/data/user/0/***/cache/subtitle_cache`, but the 2nd one needs root permission.
  - Here is some cached deduplicated subtitles (via `adb shell ls subtitle_cache -lt`):
    ```
    a51x://storage/emulated/0/Android/data/InfinityLoop1309.NewPipeEnhanced.debug/cache $ ls subtitle_cache -lt
    total 556
    -rw-rw---- 1 u0_a493 sdcard_rw 230477 2025-08-12 01:54 lUDPjyfmJrs-deduplicated&lang=ja&fmt=ttml
    -rw-rw---- 1 u0_a493 sdcard_rw 164901 2025-08-12 01:54 lUDPjyfmJrs-deduplicated&lang=id&fmt=ttml
    -rw-rw---- 1 u0_a493 sdcard_rw 164693 2025-08-12 01:54 lUDPjyfmJrs-deduplicated&lang=en&fmt=ttml
    ```
  - Filenames now use `<videoId>-deduplicated&lang=<lang>&fmt=ttml` format or added a ****&tlang=<tlang> for unique identification.

- **How to deduplicate**:
  - Core function is checkAndDeduplicate()--->deduplicateContent() in `PipePipeExtractor/extractor/src/main/java/org/schabi/newpipe/extractor/utils/SubtitleDeduplicator.java`
  - For example: The two paragraphs in the TTML is same, so containsDuplicatedEntries() finds it then delete one paragraph.
```
 <p begin="00:00:01.785" end="00:00:01.952" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​ha</span>
  <span style="s5">ai chuumoku ​</span>
  <span style="s3"></span>
  </p>
  <p begin="00:00:01.785" end="00:00:01.952" style="s2">
  <span style="s3"></span>
  ​
  <span style="s4"> ​ha</span>
  <span style="s5">ai chuumoku ​</span>
  <span style="s3"></span>
  </p>
```
  
 - **Note:**
  1). PipePipe displays subtitles in the screen with TTML subtitle file (&fmt=ttml is in the remote subtitle url).
  2). When manually downloading *.srt files, PipePipe extract paragraphs from TTML then save to *.srt file.
  3). YouTube and Firefox can highlight subtitles word by word, which is a feature defined by the `ttml` or `vtt` subtitle formats. However, PipePipe currently lacks the relevant code to render subtitles, so this effect is not available. YouTube and Firefox can highlight subtitles word by word because they parse and render the styling instructions defined in the `ttml` or `vtt` formats. In contrast, PipePipe currently only downloads and caches these subtitle files without rendering them, so the effect is not shown.
  
4. Commit ID: c37b7a0c75a1d39fefe4b4f35c8f71d0c5da6780
- Set cache directory for SubtitleDeduplicator (associated with issue https://github.com/InfinityLoop1308/PipePipe/issues/1198)

5. Commit ID: 4502acb9e5ba8b53766d62cd3ba53b884a570cac
- Support local subtitle downloads after deduplication.

