### PR TITLE
Fix bad entry in french strings.xml

### DIFF
--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -880,7 +880,7 @@ Vous devez l\'accepter pour nous envoyer le rapport de bug.</string>
 <string name="video_not_released">La vidéo n\'a pas encore été publiée.</string>
 <string name="filter_shorts_title">Filtrer les vidéos courtes</string>
 <string name="filter_shorts_summary">Supprimer les vidéos courtes des résultats. Fonctionne uniquement pour YouTube.</string>
-<string name="paid_video">Payé</string>
+<string name="paid_video">Payant</string>
 <string name="share_playlist">Partager la liste de lecture</string>
 <string name="share_playlist_with_titles_message">Partagez la liste de lecture avec des détails tels que le nom de la liste et les titres des vidéos ou comme une simple liste d\'URLs de vidéos</string>
 <string name="share_playlist_with_titles">Partager avec les titres</string>


### PR DESCRIPTION
The english word "paid" has several meanings:
1) for which payment has been made, translated in french as "payé"
2) for which payment must be made, translated in french as "payant"

In this case the second form is the correct one to use.