### PR TITLE
fix: detect access units in YouTube HLS AVC1 path

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java
@@ -9,9 +9,11 @@ import com.google.android.exoplayer2.source.SingleSampleMediaSource;
 import com.google.android.exoplayer2.source.dash.DashMediaSource;
 import com.google.android.exoplayer2.source.dash.DefaultDashChunkSource;
 import com.google.android.exoplayer2.source.hls.HlsMediaSource;
+import com.google.android.exoplayer2.source.hls.DefaultHlsExtractorFactory;
 import com.google.android.exoplayer2.source.hls.playlist.DefaultHlsPlaylistTracker;
 import com.google.android.exoplayer2.source.smoothstreaming.DefaultSsChunkSource;
 import com.google.android.exoplayer2.source.smoothstreaming.SsMediaSource;
+import com.google.android.exoplayer2.extractor.ts.DefaultTsPayloadReaderFactory;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DefaultDataSource;
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource;
@@ -183,7 +185,9 @@ public class PlayerDataSource {
     public HlsMediaSource.Factory getYoutubeHlsMediaSourceFactory() {
         cacheDataSourceFactoryBuilder.setUpstreamDataSourceFactory(
                 getYoutubeHttpDataSourceFactory(false, false));
-        return new HlsMediaSource.Factory(cacheDataSourceFactoryBuilder.build());
+        final int payloadReaderFlags = DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS;
+        return new HlsMediaSource.Factory(cacheDataSourceFactoryBuilder.build())
+                .setExtractorFactory(new DefaultHlsExtractorFactory(payloadReaderFlags, true));
     }
 
     public ProgressiveMediaSource.Factory getYoutubeProgressiveMediaSourceFactory() {


### PR DESCRIPTION
## Summary
This PR fixes severe AVC1/H264 stutter on affected Pixel devices by changing YouTube HLS extractor configuration in one localized code path.

The patch is small because the root cause is localized: enabling access-unit detection in the YouTube HLS TS parsing path resolves the reproduced stutter behavior.

## Related reports
- https://github.com/InfinityLoop1308/PipePipeClient/issues/23
- https://github.com/InfinityLoop1308/PipePipe/issues/2074
- https://github.com/InfinityLoop1308/PipePipe/issues/2045
- https://github.com/TeamNewPipe/NewPipe/issues/13062#issuecomment-3797267053

## Problem
On affected Pixel devices, YouTube AVC1/H264 playback can stutter heavily (audio remains in sync), with bursty dropped-frame patterns.
Observed decoder path on repro device: `c2.exynos.h264.decoder`.

## Investigation highlights
- Reproduced outside PipePipe UI (Media3 demo), so this is not a PipePipe UI-thread issue.
- Cross-device comparison showed decoder/device specificity:
  - Pixel 8: reproducible drops
  - Z Fold 5 (`c2.qti.avc.decoder`): same stream family smooth
- Bitrate-only hypothesis was ruled out (re-encodes at different bitrates were stable).
- A/B testing pointed to HLS AVC1 access-unit parsing/feeding behavior.

## Code change
File:
- `app/src/main/java/org/schabi/newpipe/player/helper/PlayerDataSource.java`

Change in `getYoutubeHlsMediaSourceFactory()`:
- enable `DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS`
- use `DefaultHlsExtractorFactory(payloadReaderFlags, true)`

This adjusts how H264 TS payload is split into access units before decoder input.

## Validation (A/B, same repro setup)
- detect-AU ON: `0 / 0 / 0 / 0 / 0 / 0 / 0` dropped frames (7 runs)
- detect-AU OFF (control): `13 / 312 / 573` dropped frames (3 runs)

Also validated in continuous real-device usage after patch: playback remained smooth.

## Scope
- YouTube HLS extractor path only
- No codec forcing
- No quality forcing
- No UI behavior changes
- DASH/progressive paths unchanged

## Build verification
- Local build passes with this change: `:app:assembleDebug`