### PR TITLE
Fast forward if play queue has 1 item

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3416,7 +3416,12 @@ public final class Player implements
         if (playQueue == null) {
             return;
         }
-
+        
+        if (playQueue.size() == 1)
+        {
+            fastForward();
+            return;
+        }
         saveStreamProgressState();
         playQueue.offsetIndex(+1);
         triggerProgressUpdate();


### PR DESCRIPTION
Hey there! 

I ended up just putting the fast forward function in for now. I took a look at doing fast rewind as well, but it looks like play previous already has the function of rewinding the current video to the start. I think this is more common behavior than rewinding, which once again has me thinking about an option being necessary, but please let me know if you have other ideas! 

Thanks,
Kristian
