### PR TITLE
Add Enqueue option to external URL open dialog

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -503,6 +503,13 @@ public class RouterActivity extends AppCompatActivity {
             }
         }
 
+        if (PlayerHolder.getInstance().getQueueSize() > 0) {
+            returnList.add(new AdapterChoiceItem(
+                    getString(R.string.enqueue_key),
+                    getString(R.string.enqueue_stream),
+                    R.drawable.ic_add));
+        }
+
         return returnList;
     }
 
@@ -791,6 +798,9 @@ public class RouterActivity extends AppCompatActivity {
                     NavigationHelper.playOnBackgroundPlayer(this, playQueue, true);
                 } else if (choice.playerChoice.equals(popupPlayerKey)) {
                     NavigationHelper.playOnPopupPlayer(this, playQueue, true);
+                } else if (choice.playerChoice.equals(
+                        getString(R.string.enqueue_key))) {
+                    NavigationHelper.enqueueOnPlayer(this, playQueue);
                 }
             };
         }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1684,4 +1684,5 @@
         <item>enqueue</item>
         <item>disable</item>
     </string-array>
+    <string name="enqueue_key">enqueue</string>
 </resources>


### PR DESCRIPTION
## Summary
- Adds "Enqueue" option to the share/open dialog when opening external YouTube links
- Only appears when a player is already active with items in queue
- Appends the stream to current play queue without interrupting playback
- Ported from NewPipe's RouterActivity enqueue feature

## Changes
- `RouterActivity.getChoicesForService()`: adds enqueue choice (conditional on queue > 0)
- `RouterActivity.FetcherService.getResultHandler()`: routes enqueue to `NavigationHelper.enqueueOnPlayer()`
- `settings_keys.xml`: adds `enqueue_key` string resource

## Test plan
- [ ] Open a video in PipePipe, start playing
- [ ] Share a different YouTube link to PipePipe
- [ ] Verify "Enqueue" option appears in the dialog
- [ ] Tap Enqueue, verify video is added to queue without interrupting current playback
- [ ] Verify "Enqueue" does NOT appear when no player is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)