### PR TITLE
feat(podcast): add audio-first podcast flow and recommendations

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ChannelTabHelper.java
@@ -30,6 +30,8 @@ public final class ChannelTabHelper {
                 return R.string.show_channel_tabs_channels;
             case ChannelTabs.ALBUMS:
                 return R.string.show_channel_tabs_albums;
+            case ChannelTabs.PODCASTS:
+                return R.string.show_channel_tabs_podcasts;
         }
         return -1;
     }
@@ -63,6 +65,8 @@ public final class ChannelTabHelper {
                 return R.string.channel_tab_channels;
             case ChannelTabs.ALBUMS:
                 return R.string.channel_tab_albums;
+            case ChannelTabs.PODCASTS:
+                return R.string.channel_tab_podcasts;
         }
         return R.string.unknown_content;
     }

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -271,6 +271,7 @@
         <item>@string/show_channel_tabs_shorts</item>
         <item>@string/show_channel_tabs_channels</item>
         <item>@string/show_channel_tabs_albums</item>
+        <item>@string/show_channel_tabs_podcasts</item>
         <item>@string/show_channel_tabs_info</item>
     </string-array>
     <string-array name="show_channel_tabs_description_list">
@@ -279,6 +280,7 @@
         <item>@string/channel_tab_shorts</item>
         <item>@string/channel_tab_channels</item>
         <item>@string/channel_tab_albums</item>
+        <item>@string/channel_tab_podcasts</item>
         <item>@string/channel_tab_info</item>
     </string-array>
     <string name="show_search_suggestions_key">show_search_suggestions</string>
@@ -1684,7 +1686,6 @@
         <item>enqueue</item>
         <item>disable</item>
     </string-array>
-
     <string name="grid_layout_enabled_key">grid_layout_enabled_key</string>
     <string name="grid_columns_key">grid_columns_key</string>
     <string name="grid_columns_landscape_key">grid_columns_landscape_key</string>
@@ -1710,4 +1711,6 @@
         <item>7</item>
         <item>8</item>
     </string-array>
+
+    <string name="show_channel_tabs_podcasts">show_channel_tabs_podcasts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1120,4 +1120,5 @@
 <string name="grid_layout_summary">Show supported lists in a grid instead of a single-column list</string>
 <string name="grid_columns_title">Grid columns</string>
 <string name="grid_columns_landscape_title">Grid columns (landscape)</string>
+<string name="channel_tab_podcasts">Podcasts</string>
 </resources>


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipe/issues/577

## Commits
- https://github.com/Priveetee/PipePipeClient/commit/1424b52eb
- https://github.com/Priveetee/PipePipeClient/commit/62804be2f
- https://github.com/Priveetee/PipePipeClient/commit/062204871

## Summary
- Expose Podcasts tab in channel tab settings/labels.
- Implement podcast-first flow:
  - Channel > Podcasts: tapping a playlist opens the playlist so user can choose an episode.
  - In podcast context, tapping an episode starts background audio and opens detail screen with queue context.
- In podcast detail context, keep comments/description and route recommendations to podcast feed behavior.
- Add audio-first click behavior for `Recommended Podcasts` kiosk and use mini list variant to reduce scroll jank.

## Why
- #577 is not only tab visibility; users need a podcast-oriented interaction model (choose episodes, background audio first, preserve detail affordances).

## Validation
- Build validation:
  - `JAVA_HOME=/usr/lib/jvm/java-11-openjdk ./gradlew :app:assembleDebug` ✅
- Device validation (ADB, Pixel):
  - podcast tab populated on `@Mémoire-vive`
  - playlist opens on tap from Podcasts tab
  - episode tap triggers background audio and opens detail
  - comments/description remain available

## Notes
- Commits are intentionally split and each stays under 290 insertions.
- Generated schema file `app/schemas/org.schabi.newpipe.database.AppDatabase/901.json` is intentionally excluded from this PR.
- Branch was synced with upstream `dev` to resolve conflicts (`Merge upstream/dev into dev`).
- This client PR is intended to be reviewed with extractor changes that add podcast-tab/kiosk extraction support.