### PR TITLE
UI: add channel tab sort menu

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelVideosFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelVideosFragment.java
@@ -548,16 +548,27 @@ public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, 
                 .setTitle(R.string.sort)
                 .setSingleChoiceItems(sortFilterLabels, getSelectedSortFilterIndex(sortFilterItems),
                         (dialog, which) -> {
-                            selectedSortFilterId = sortFilterItems.get(which).getIdentifier();
+                            final int selectedFilterId = getNormalizedSortFilterId(
+                                    sortFilterItems.get(which));
                             dialog.dismiss();
+                            if (selectedFilterId == selectedSortFilterId) {
+                                return;
+                            }
+                            selectedSortFilterId = selectedFilterId;
                             startLoading(true);
                         })
                 .show();
     }
 
+    private int getNormalizedSortFilterId(final FilterItem sortFilterItem) {
+        return "latest".equals(sortFilterItem.getName())
+                ? Filter.ITEM_IDENTIFIER_UNKNOWN
+                : sortFilterItem.getIdentifier();
+    }
+
     private int getSelectedSortFilterIndex(final List<FilterItem> sortFilterItems) {
         for (int i = 0; i < sortFilterItems.size(); i++) {
-            if (sortFilterItems.get(i).getIdentifier() == selectedSortFilterId) {
+            if (getNormalizedSortFilterId(sortFilterItems.get(i)) == selectedSortFilterId) {
                 return i;
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelVideosFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelVideosFragment.java
@@ -11,12 +11,17 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageButton;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.content.ContextCompat;
 
 import com.google.android.material.snackbar.Snackbar;
@@ -31,9 +36,17 @@ import org.schabi.newpipe.databinding.PlaylistControlBinding;
 import org.schabi.newpipe.error.ErrorInfo;
 import org.schabi.newpipe.error.ErrorUtil;
 import org.schabi.newpipe.error.UserAction;
+import org.schabi.newpipe.extractor.InfoItem;
 import org.schabi.newpipe.extractor.ListExtractor;
+import org.schabi.newpipe.extractor.NewPipe;
 import org.schabi.newpipe.extractor.channel.ChannelInfo;
+import org.schabi.newpipe.extractor.channel.ChannelTabInfo;
 import org.schabi.newpipe.extractor.exceptions.ContentNotSupportedException;
+import org.schabi.newpipe.extractor.linkhandler.ChannelTabs;
+import org.schabi.newpipe.extractor.linkhandler.ListLinkHandler;
+import org.schabi.newpipe.extractor.search.filter.Filter;
+import org.schabi.newpipe.extractor.search.filter.FilterGroup;
+import org.schabi.newpipe.extractor.search.filter.FilterItem;
 import org.schabi.newpipe.extractor.stream.StreamInfoItem;
 import org.schabi.newpipe.fragments.list.BaseListInfoFragment;
 import org.schabi.newpipe.ktx.AnimationType;
@@ -47,13 +60,17 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PicassoHelper;
+import org.schabi.newpipe.util.ServiceHelper;
 import org.schabi.newpipe.util.ThemeHelper;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import icepick.State;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
@@ -64,8 +81,6 @@ import io.reactivex.rxjava3.functions.Consumer;
 import io.reactivex.rxjava3.functions.Function;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 
-import android.widget.ImageButton;
-
 public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, ChannelInfo>
         implements View.OnClickListener {
 
@@ -74,6 +89,10 @@ public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, 
 
     private final CompositeDisposable disposables = new CompositeDisposable();
     private Disposable subscribeButtonMonitor;
+    private MenuItem menuSortButton;
+
+    @State
+    protected int selectedSortFilterId = Filter.ITEM_IDENTIFIER_UNKNOWN;
 
     private boolean channelContentNotSupported = false;
 
@@ -123,7 +142,31 @@ public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setHasOptionsMenu(false);
+        setHasOptionsMenu(true);
+    }
+
+    @Override
+    public void onCreateOptionsMenu(@NonNull final Menu menu,
+                                    @NonNull final MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+        inflater.inflate(R.menu.menu_channel_videos, menu);
+        menuSortButton = menu.findItem(R.id.menu_item_sort);
+        updateSortButton();
+    }
+
+    @Override
+    public void onPrepareOptionsMenu(@NonNull final Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+        updateSortButton();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item) {
+        if (item.getItemId() == R.id.menu_item_sort) {
+            showSortDialog();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override
@@ -378,12 +421,154 @@ public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, 
 
     @Override
     protected Single<ListExtractor.InfoItemsPage<StreamInfoItem>> loadMoreItemsLogic() {
+        if (selectedSortFilterId != Filter.ITEM_IDENTIFIER_UNKNOWN && currentInfo != null) {
+            return Single.fromCallable(() -> getSortedVideosTabHandler(currentInfo))
+                    .flatMap(handler -> handler == null
+                            ? ExtractorHelper.getMoreChannelItems(serviceId, url, currentNextPage)
+                            : ExtractorHelper.getMoreChannelTabItems(serviceId, handler,
+                                    currentNextPage).map(this::toStreamItemsPage));
+        }
         return ExtractorHelper.getMoreChannelItems(serviceId, url, currentNextPage);
     }
 
     @Override
     protected Single<ChannelInfo> loadResult(final boolean forceLoad) {
-        return ExtractorHelper.getChannelInfo(serviceId, url, forceLoad);
+        if (selectedSortFilterId == Filter.ITEM_IDENTIFIER_UNKNOWN) {
+            return ExtractorHelper.getChannelInfo(serviceId, url, forceLoad);
+        }
+
+        return Single.fromCallable(() -> ChannelInfo.getInfo(NewPipe.getService(serviceId), url))
+                .flatMap(channelInfo -> loadSortedChannelInfo(channelInfo, forceLoad));
+    }
+
+    private Single<ChannelInfo> loadSortedChannelInfo(final ChannelInfo channelInfo,
+                                                      final boolean forceLoad) {
+        return Single.fromCallable(() -> getSortedVideosTabHandler(channelInfo))
+                .flatMap(handler -> handler == null
+                        ? Single.just(channelInfo)
+                        : ExtractorHelper.getChannelTab(serviceId, handler, forceLoad)
+                                .map(channelTabInfo -> applyChannelTabInfo(
+                                        channelInfo, channelTabInfo)));
+    }
+
+    private ChannelInfo applyChannelTabInfo(final ChannelInfo channelInfo,
+                                            final ChannelTabInfo channelTabInfo) {
+        channelInfo.setRelatedItems(channelTabInfo.getRelatedItems().stream()
+                .filter(StreamInfoItem.class::isInstance)
+                .map(StreamInfoItem.class::cast)
+                .collect(Collectors.toList()));
+        channelInfo.setNextPage(channelTabInfo.getNextPage());
+        return channelInfo;
+    }
+
+    private ListExtractor.InfoItemsPage<StreamInfoItem> toStreamItemsPage(
+            final ListExtractor.InfoItemsPage<InfoItem> infoItemsPage) {
+        final List<StreamInfoItem> streamItems = infoItemsPage.getItems().stream()
+                .filter(StreamInfoItem.class::isInstance)
+                .map(StreamInfoItem.class::cast)
+                .collect(Collectors.toList());
+
+        return new ListExtractor.InfoItemsPage<>(streamItems,
+                infoItemsPage.getNextPage(), infoItemsPage.getErrors());
+    }
+
+    @Nullable
+    private ListLinkHandler getSortedVideosTabHandler(final ChannelInfo channelInfo)
+            throws Exception {
+        final ListLinkHandler videosTabHandler = getVideosTabHandler(channelInfo);
+        final FilterItem selectedSortFilter = getSelectedSortFilterItem();
+        if (videosTabHandler == null || selectedSortFilter == null) {
+            return null;
+        }
+
+        return NewPipe.getService(serviceId).getChannelTabLHFactory().fromQuery(
+                videosTabHandler.getId(),
+                videosTabHandler.getContentFilters(),
+                Collections.singletonList(selectedSortFilter));
+    }
+
+    @Nullable
+    private ListLinkHandler getVideosTabHandler(@Nullable final ChannelInfo channelInfo) {
+        if (channelInfo == null) {
+            return null;
+        }
+
+        for (final ListLinkHandler linkHandler : channelInfo.getTabs()) {
+            if (!linkHandler.getContentFilters().isEmpty()
+                    && ChannelTabs.VIDEOS.equals(linkHandler.getContentFilters().get(0).getName())) {
+                return linkHandler;
+            }
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private FilterItem getSelectedSortFilterItem() throws Exception {
+        for (final FilterItem sortFilterItem : getChannelTabSortFilterItems()) {
+            if (sortFilterItem.getIdentifier() == selectedSortFilterId) {
+                return sortFilterItem;
+            }
+        }
+
+        return null;
+    }
+
+    private List<FilterItem> getChannelTabSortFilterItems() {
+        try {
+            final Filter sortFilter = NewPipe.getService(serviceId)
+                    .getChannelTabLHFactory()
+                    .getAvailableSortFilter();
+            if (sortFilter == null || sortFilter.getFilterGroups() == null) {
+                return Collections.emptyList();
+            }
+
+            final List<FilterItem> sortFilterItems = new ArrayList<>();
+            for (final FilterGroup filterGroup : sortFilter.getFilterGroups()) {
+                Collections.addAll(sortFilterItems, filterGroup.filterItems);
+            }
+            return sortFilterItems;
+        } catch (final Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    private void showSortDialog() {
+        final List<FilterItem> sortFilterItems = getChannelTabSortFilterItems();
+        if (sortFilterItems.isEmpty()) {
+            return;
+        }
+
+        final String[] sortFilterLabels = sortFilterItems.stream()
+                .map(filterItem -> ServiceHelper.getTranslatedFilterString(
+                        filterItem.getName(), requireContext()))
+                .toArray(String[]::new);
+
+        new AlertDialog.Builder(requireContext())
+                .setTitle(R.string.sort)
+                .setSingleChoiceItems(sortFilterLabels, getSelectedSortFilterIndex(sortFilterItems),
+                        (dialog, which) -> {
+                            selectedSortFilterId = sortFilterItems.get(which).getIdentifier();
+                            dialog.dismiss();
+                            startLoading(true);
+                        })
+                .show();
+    }
+
+    private int getSelectedSortFilterIndex(final List<FilterItem> sortFilterItems) {
+        for (int i = 0; i < sortFilterItems.size(); i++) {
+            if (sortFilterItems.get(i).getIdentifier() == selectedSortFilterId) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    private void updateSortButton() {
+        if (menuSortButton != null) {
+            menuSortButton.setVisible(getVideosTabHandler(currentInfo) != null
+                    && !getChannelTabSortFilterItems().isEmpty());
+        }
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -433,6 +618,8 @@ public class ChannelVideosFragment extends BaseListInfoFragment<StreamInfoItem, 
         super.handleResult(result);
 
         headerBinding.getRoot().setVisibility(View.VISIBLE);
+        updateSortButton();
+        activity.invalidateOptionsMenu();
         PicassoHelper.loadBanner(result.getBannerUrl()).tag(PICASSO_CHANNEL_TAG)
                 .into(headerBinding.channelBannerImage);
         PicassoHelper.loadAvatar(result.getAvatarUrl()).tag(PICASSO_CHANNEL_TAG)

--- a/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ServiceHelper.java
@@ -97,6 +97,12 @@ public final class ServiceHelper {
                 return c.getString(R.string.sortorder);
             case "features":
                 return c.getString(R.string.features);
+            case "latest":
+                return c.getString(R.string.newest_first);
+            case "popular":
+                return c.getString(R.string.sort_popular);
+            case "oldest":
+                return c.getString(R.string.oldest_first);
             case "sort_popular":
                 return c.getString(R.string.sort_popular);
             case "sort_view":

--- a/app/src/main/res/menu/menu_channel_videos.xml
+++ b/app/src/main/res/menu/menu_channel_videos.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/menu_item_sort"
+        android:icon="@drawable/ic_sort"
+        android:title="@string/sort"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
Refs https://github.com/InfinityLoop1308/PipePipe/issues/1279

## Commits
- https://github.com/Priveetee/PipePipeClient/commit/0df20f85f
- https://github.com/Priveetee/PipePipeClient/commit/56bbf81a9

## Summary
- Add a Sort menu item on channel videos.
- Add `Newest first`, `Popular` and `Oldest first` choices.
- Reload channel videos when changing sort.
- Keep pagination working for sorted channel videos.
- Avoid reloading when selecting the current sort again.

## Why
- https://github.com/InfinityLoop1308/PipePipe/issues/1279 asks for channel video sorting in the client UI.

## Validation
- `./gradlew :app:assembleDebug`
- Installed debug APK on Pixel Phone.
- Tested switching between Newest first, Popular and Oldest first on a YouTube channel.
- Tested thumbnails and pagination.
- Verified repeated current-sort selection does not reload.
