### PR TITLE
cleanup(download): simplify HLS routing and parser

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/RouterActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/RouterActivity.java
@@ -64,6 +64,7 @@ import org.schabi.newpipe.util.ExtractorHelper;
 import org.schabi.newpipe.util.Localization;
 import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.PermissionHelper;
+import org.schabi.newpipe.util.StreamTypeUtil;
 import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 import org.schabi.newpipe.util.urlfinder.UrlFinder;
@@ -627,6 +628,13 @@ public class RouterActivity extends AppCompatActivity {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(result -> {
+                    if (StreamTypeUtil.isLiveStream(result.getStreamType())) {
+                        Toast.makeText(this, R.string.no_streams_available_download,
+                                Toast.LENGTH_LONG).show();
+                        finish();
+                        return;
+                    }
+
                     final FragmentManager fm = getSupportFragmentManager();
                     final DownloadDialog downloadDialog =
                             DownloadDialog.newInstance(this, result);

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -1128,10 +1128,14 @@ public class DownloadDialog extends DialogFragment
                     new MissionRecoveryInfo(secondaryStream)};
         }
 
-        resourceDeliveryMethods = buildResourceDeliveryMethods(selectedStream, secondaryStream);
-        resourceManifestUrls = buildResourceManifestUrls(selectedStream, secondaryStream);
-        resourceIsUrls = buildResourceIsUrls(selectedStream, secondaryStream);
-        if (containsHlsResource(resourceDeliveryMethods, resourceManifestUrls, urls)) {
+        resourceDeliveryMethods = HlsDownloadStreamHelper
+                .buildResourceDeliveryMethods(selectedStream, secondaryStream);
+        resourceManifestUrls = HlsDownloadStreamHelper
+                .buildResourceManifestUrls(selectedStream, secondaryStream);
+        resourceIsUrls = HlsDownloadStreamHelper
+                .buildResourceIsUrls(selectedStream, secondaryStream);
+        if (HlsDownloadStreamHelper.containsHlsResource(resourceDeliveryMethods,
+                resourceManifestUrls, urls)) {
             psName = null;
             psArgs = null;
         }
@@ -1144,57 +1148,5 @@ public class DownloadDialog extends DialogFragment
                 Toast.LENGTH_SHORT).show();
 
         dismiss();
-    }
-
-    private String[] buildResourceDeliveryMethods(@NonNull final Stream selectedStream,
-                                                  @Nullable final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new String[]{selectedStream.getDeliveryMethod().name()};
-        }
-        return new String[]{
-                selectedStream.getDeliveryMethod().name(),
-                secondaryStream.getDeliveryMethod().name()
-        };
-    }
-
-    private String[] buildResourceManifestUrls(@NonNull final Stream selectedStream,
-                                               @Nullable final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new String[]{selectedStream.getManifestUrl()};
-        }
-        return new String[]{selectedStream.getManifestUrl(), secondaryStream.getManifestUrl()};
-    }
-
-    private boolean[] buildResourceIsUrls(@NonNull final Stream selectedStream,
-                                          @Nullable final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new boolean[]{selectedStream.isUrl()};
-        }
-        return new boolean[]{selectedStream.isUrl(), secondaryStream.isUrl()};
-    }
-
-    private boolean containsHlsResource(final String[] deliveryMethods,
-                                        final String[] manifestUrls,
-                                        final String[] urls) {
-        for (final String method : deliveryMethods) {
-            if ("HLS".equals(method)) {
-                return true;
-            }
-        }
-        for (final String manifestUrl : manifestUrls) {
-            if (looksLikeHls(manifestUrl)) {
-                return true;
-            }
-        }
-        for (final String url : urls) {
-            if (looksLikeHls(url)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean looksLikeHls(@Nullable final String value) {
-        return value != null && value.toLowerCase(Locale.ROOT).contains(".m3u8");
     }
 }

--- a/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
+++ b/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 // Keep for BiliBili video case if it writes to outputstream directly
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import static org.schabi.newpipe.util.FilenameUtils.createFilename;
 
@@ -267,10 +266,14 @@ public class DirectDownloader {
                     new MissionRecoveryInfo(secondaryStream)};
         }
 
-        resourceDeliveryMethods = buildResourceDeliveryMethods(selectedStream, secondaryStream);
-        resourceManifestUrls = buildResourceManifestUrls(selectedStream, secondaryStream);
-        resourceIsUrls = buildResourceIsUrls(selectedStream, secondaryStream);
-        if (containsHlsResource(resourceDeliveryMethods, resourceManifestUrls, urls)) {
+        resourceDeliveryMethods = HlsDownloadStreamHelper
+                .buildResourceDeliveryMethods(selectedStream, secondaryStream);
+        resourceManifestUrls = HlsDownloadStreamHelper
+                .buildResourceManifestUrls(selectedStream, secondaryStream);
+        resourceIsUrls = HlsDownloadStreamHelper
+                .buildResourceIsUrls(selectedStream, secondaryStream);
+        if (HlsDownloadStreamHelper.containsHlsResource(resourceDeliveryMethods,
+                resourceManifestUrls, urls)) {
             psName = null;
             psArgs = null;
         }
@@ -278,57 +281,5 @@ public class DirectDownloader {
         DownloadManagerService.startMission(context, urls, storage, kind, threads,
                 currentInfo.getUrl(), psName, psArgs, nearLength, recoveryInfo,
                 resourceDeliveryMethods, resourceManifestUrls, resourceIsUrls);
-    }
-
-    private String[] buildResourceDeliveryMethods(final Stream selectedStream,
-                                                  final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new String[]{selectedStream.getDeliveryMethod().name()};
-        }
-        return new String[]{
-                selectedStream.getDeliveryMethod().name(),
-                secondaryStream.getDeliveryMethod().name()
-        };
-    }
-
-    private String[] buildResourceManifestUrls(final Stream selectedStream,
-                                               final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new String[]{selectedStream.getManifestUrl()};
-        }
-        return new String[]{selectedStream.getManifestUrl(), secondaryStream.getManifestUrl()};
-    }
-
-    private boolean[] buildResourceIsUrls(final Stream selectedStream,
-                                          final Stream secondaryStream) {
-        if (secondaryStream == null) {
-            return new boolean[]{selectedStream.isUrl()};
-        }
-        return new boolean[]{selectedStream.isUrl(), secondaryStream.isUrl()};
-    }
-
-    private boolean containsHlsResource(final String[] deliveryMethods,
-                                        final String[] manifestUrls,
-                                        final String[] urls) {
-        for (final String method : deliveryMethods) {
-            if ("HLS".equals(method)) {
-                return true;
-            }
-        }
-        for (final String manifestUrl : manifestUrls) {
-            if (looksLikeHls(manifestUrl)) {
-                return true;
-            }
-        }
-        for (final String url : urls) {
-            if (looksLikeHls(url)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean looksLikeHls(final String value) {
-        return value != null && value.toLowerCase(Locale.ROOT).contains(".m3u8");
     }
 }

--- a/app/src/main/java/us/shandian/giga/get/DownloadMission.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMission.java
@@ -634,35 +634,8 @@ public class DownloadMission extends Mission {
     }
 
     boolean hasHlsResource() {
-        if (resourceDeliveryMethods != null) {
-            for (String method : resourceDeliveryMethods) {
-                if ("HLS".equals(method)) {
-                    return true;
-                }
-            }
-        }
-
-        if (urls != null) {
-            for (String url : urls) {
-                if (looksLikeHls(url)) {
-                    return true;
-                }
-            }
-        }
-
-        if (resourceManifestUrls != null) {
-            for (String url : resourceManifestUrls) {
-                if (looksLikeHls(url)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private boolean looksLikeHls(String url) {
-        return url != null && url.toLowerCase().contains(".m3u8");
+        return HlsDownloadStreamHelper.containsHlsResource(resourceDeliveryMethods,
+                resourceManifestUrls, urls);
     }
 
     /**

--- a/app/src/main/java/us/shandian/giga/get/HlsDownloadStreamHelper.java
+++ b/app/src/main/java/us/shandian/giga/get/HlsDownloadStreamHelper.java
@@ -2,11 +2,13 @@ package us.shandian.giga.get;
 
 import org.schabi.newpipe.extractor.MediaFormat;
 import org.schabi.newpipe.extractor.stream.DeliveryMethod;
+import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.StreamType;
 import org.schabi.newpipe.extractor.stream.VideoStream;
 
 import java.util.List;
+import java.util.Locale;
 
 public final class HlsDownloadStreamHelper {
     public static final String HLS_MANIFEST_RESOLUTION = "HLS";
@@ -54,6 +56,45 @@ public final class HlsDownloadStreamHelper {
                 && HLS_MANIFEST_RESOLUTION.equals(recovery.getDesired());
     }
 
+    public static String[] buildResourceDeliveryMethods(final Stream selectedStream,
+                                                        final Stream secondaryStream) {
+        if (secondaryStream == null) {
+            return new String[]{selectedStream.getDeliveryMethod().name()};
+        }
+        return new String[]{
+                selectedStream.getDeliveryMethod().name(),
+                secondaryStream.getDeliveryMethod().name()
+        };
+    }
+
+    public static String[] buildResourceManifestUrls(final Stream selectedStream,
+                                                     final Stream secondaryStream) {
+        if (secondaryStream == null) {
+            return new String[]{selectedStream.getManifestUrl()};
+        }
+        return new String[]{selectedStream.getManifestUrl(), secondaryStream.getManifestUrl()};
+    }
+
+    public static boolean[] buildResourceIsUrls(final Stream selectedStream,
+                                                final Stream secondaryStream) {
+        if (secondaryStream == null) {
+            return new boolean[]{selectedStream.isUrl()};
+        }
+        return new boolean[]{selectedStream.isUrl(), secondaryStream.isUrl()};
+    }
+
+    public static boolean containsHlsResource(final String[] deliveryMethods,
+                                             final String[] manifestUrls,
+                                             final String[] urls) {
+        return containsHlsMethod(deliveryMethods)
+                || containsHlsValue(manifestUrls)
+                || containsHlsValue(urls);
+    }
+
+    public static boolean looksLikeHls(final String value) {
+        return value != null && value.toLowerCase(Locale.ROOT).contains(".m3u8");
+    }
+
     private static boolean hasNonHlsStream(final List<VideoStream> streams) {
         for (final VideoStream stream : streams) {
             if (stream.getDeliveryMethod() != DeliveryMethod.HLS) {
@@ -68,6 +109,30 @@ public final class HlsDownloadStreamHelper {
             if (stream.getDeliveryMethod() == DeliveryMethod.HLS
                     || hlsUrl.equals(stream.getContent())
                     || hlsUrl.equals(stream.getManifestUrl())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsHlsMethod(final String[] values) {
+        if (values == null) {
+            return false;
+        }
+        for (final String value : values) {
+            if (DeliveryMethod.HLS.name().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsHlsValue(final String[] values) {
+        if (values == null) {
+            return false;
+        }
+        for (final String value : values) {
+            if (looksLikeHls(value)) {
                 return true;
             }
         }

--- a/app/src/main/java/us/shandian/giga/get/HlsDownloader.kt
+++ b/app/src/main/java/us/shandian/giga/get/HlsDownloader.kt
@@ -297,15 +297,15 @@ internal class HlsDownloader(
             throw IOException("Inline HLS manifests are not supported by HlsDownloader yet")
         }
         return when {
-            !manifestUrl.isNullOrBlank() && looksLikeHls(manifestUrl) -> manifestUrl
+            !manifestUrl.isNullOrBlank() && HlsDownloadStreamHelper.looksLikeHls(manifestUrl) -> manifestUrl
             else -> url
         }
     }
 
     private fun isHlsResource(index: Int): Boolean {
         return mission.resourceDeliveryMethods?.getOrNull(index) == "HLS" ||
-            looksLikeHls(mission.resourceManifestUrls?.getOrNull(index)) ||
-            looksLikeHls(mission.urls.getOrNull(index))
+            HlsDownloadStreamHelper.looksLikeHls(mission.resourceManifestUrls?.getOrNull(index)) ||
+            HlsDownloadStreamHelper.looksLikeHls(mission.urls.getOrNull(index))
     }
 
     private fun updateResourceCheckpoint(resourceCheckpoint: HlsResourceCheckpoint) {
@@ -334,10 +334,6 @@ internal class HlsDownloader(
 
     private fun quote(value: String): String {
         return '"' + value.replace("\\", "\\\\").replace("\"", "\\\"") + '"'
-    }
-
-    private fun looksLikeHls(value: String?): Boolean {
-        return value?.contains(".m3u8", ignoreCase = true) == true
     }
 
     private fun outputExtension(): String {

--- a/app/src/main/java/us/shandian/giga/hls/manifest/HlsPlaylistParser.kt
+++ b/app/src/main/java/us/shandian/giga/hls/manifest/HlsPlaylistParser.kt
@@ -1,227 +1,152 @@
 package us.shandian.giga.hls.manifest
 
+import android.net.Uri
+import com.google.android.exoplayer2.C
+import com.google.android.exoplayer2.Format
+import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist as ExoHlsMediaPlaylist
+import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist.Segment as ExoHlsSegment
+import com.google.android.exoplayer2.source.hls.playlist.HlsMediaPlaylist.SegmentBase as ExoHlsSegmentBase
+import com.google.android.exoplayer2.source.hls.playlist.HlsMultivariantPlaylist as ExoHlsMultivariantPlaylist
+import com.google.android.exoplayer2.source.hls.playlist.HlsPlaylistParser as ExoHlsPlaylistParser
+import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.net.URI
-import java.util.Locale
 
 class HlsPlaylistParser {
     @Throws(IOException::class)
     fun parse(sourceUrl: String, body: String): HlsPlaylist {
-        val lines = body.lineSequence()
-            .map { it.trim().trimStart('\uFEFF') }
-            .filter { it.isNotEmpty() }
-            .toList()
-
-        if (lines.none { it == EXTM3U }) {
-            throw IOException("HLS playlist missing $EXTM3U firstLine=${safeLineSnippet(lines.firstOrNull())}")
+        val input = ByteArrayInputStream(body.toByteArray(Charsets.UTF_8))
+        return when (val playlist = ExoHlsPlaylistParser().parse(Uri.parse(sourceUrl), input)) {
+            is ExoHlsMediaPlaylist -> playlist.toInternalMediaPlaylist(sourceUrl)
+            is ExoHlsMultivariantPlaylist -> playlist.toInternalMasterPlaylist(sourceUrl)
+            else -> throw IOException("Unsupported HLS playlist type: ${playlist.javaClass.name}")
         }
-
-        val variants = parseVariants(sourceUrl, lines)
-        if (variants.isNotEmpty()) {
-            return HlsMasterPlaylist(sourceUrl, variants)
-        }
-
-        return parseMediaPlaylist(sourceUrl, lines)
     }
 
-    private fun parseVariants(sourceUrl: String, lines: List<String>): List<HlsVariant> {
-        val variants = mutableListOf<HlsVariant>()
-        var pendingAttributes: Map<String, String>? = null
-
-        for (line in lines) {
-            when {
-                line.startsWith(EXT_X_STREAM_INF) -> {
-                    pendingAttributes = parseAttributes(line.substringAfter(':'))
-                }
-                pendingAttributes != null && !line.startsWith('#') -> {
-                    val attributes = pendingAttributes
-                    variants += HlsVariant(
-                        url = resolveUrl(sourceUrl, line),
-                        bandwidth = attributes["BANDWIDTH"]?.toLongOrNull(),
-                        averageBandwidth = attributes["AVERAGE-BANDWIDTH"]?.toLongOrNull(),
-                        codecs = attributes["CODECS"],
-                        resolution = attributes["RESOLUTION"],
-                        frameRate = attributes["FRAME-RATE"]?.toDoubleOrNull(),
-                        audioGroupId = attributes["AUDIO"],
-                    )
-                    pendingAttributes = null
-                }
-            }
-        }
-
-        return variants
+    private fun ExoHlsMultivariantPlaylist.toInternalMasterPlaylist(sourceUrl: String): HlsMasterPlaylist {
+        return HlsMasterPlaylist(
+            sourceUrl = sourceUrl,
+            variants = variants.map { variant ->
+                val format = variant.format
+                HlsVariant(
+                    url = resolveUrl(sourceUrl, variant.url.toString()),
+                    bandwidth = positiveLong(format.peakBitrate) ?: positiveLong(format.bitrate),
+                    averageBandwidth = positiveLong(format.averageBitrate),
+                    codecs = format.codecs,
+                    resolution = resolutionOf(format),
+                    frameRate = format.frameRate.takeIf { it > 0 }?.toDouble(),
+                    audioGroupId = variant.audioGroupId,
+                )
+            },
+        )
     }
 
-    private fun parseMediaPlaylist(sourceUrl: String, lines: List<String>): HlsMediaPlaylist {
-        val segments = mutableListOf<HlsSegment>()
-        var targetDuration: Double? = null
-        var mediaSequence = 0L
-        var isEndList = false
-        var pendingDuration: Double? = null
-        var pendingTitle: String? = null
-        var pendingByteRange: HlsByteRange? = null
-        var pendingDiscontinuity = false
-        var initSegment: HlsInitSegment? = null
-        var hasEncryption = false
-        var hasUnsupportedEncryption = false
-        var hasDiscontinuity = false
-        var currentEncryptionKey: HlsEncryptionKey? = null
-
-        for (line in lines) {
-            when {
-                line.startsWith(EXT_X_TARGETDURATION) -> {
-                    targetDuration = line.substringAfter(':').toDoubleOrNull()
-                }
-                line.startsWith(EXT_X_MEDIA_SEQUENCE) -> {
-                    mediaSequence = line.substringAfter(':').toLongOrNull() ?: 0L
-                }
-                line.startsWith(EXT_X_BYTERANGE) -> {
-                    pendingByteRange = parseByteRange(line.substringAfter(':'))
-                }
-                line.startsWith(EXT_X_MAP) -> {
-                    initSegment = parseInitSegment(sourceUrl, line.substringAfter(':'), currentEncryptionKey)
-                }
-                line.startsWith(EXT_X_KEY) -> {
-                    val attributes = parseAttributes(line.substringAfter(':'))
-                    val method = attributes["METHOD"]
-                    currentEncryptionKey = when {
-                        method == null || method.equals("NONE", ignoreCase = true) -> null
-                        else -> {
-                            hasEncryption = true
-                            if (!method.equals("AES-128", ignoreCase = true)) {
-                                hasUnsupportedEncryption = true
-                            }
-                            HlsEncryptionKey(
-                                method = method,
-                                url = attributes["URI"]?.let { resolveUrl(sourceUrl, it) },
-                                iv = attributes["IV"],
-                            )
-                        }
-                    }
-                }
-                line == EXT_X_DISCONTINUITY -> {
-                    pendingDiscontinuity = true
-                    hasDiscontinuity = true
-                }
-                line.startsWith(EXTINF) -> {
-                    val value = line.substringAfter(':')
-                    pendingDuration = value.substringBefore(',').toDoubleOrNull()
-                    pendingTitle = value.substringAfter(',', "").ifBlank { null }
-                }
-                line == EXT_X_ENDLIST -> {
-                    isEndList = true
-                }
-                !line.startsWith('#') -> {
-                    segments += HlsSegment(
-                        url = resolveUrl(sourceUrl, line),
-                        durationSeconds = pendingDuration,
-                        title = pendingTitle,
-                        byteRange = pendingByteRange,
-                        discontinuity = pendingDiscontinuity,
-                        encryptionKey = currentEncryptionKey,
-                    )
-                    pendingDuration = null
-                    pendingTitle = null
-                    pendingByteRange = null
-                    pendingDiscontinuity = false
-                }
-            }
-        }
-
+    private fun ExoHlsMediaPlaylist.toInternalMediaPlaylist(sourceUrl: String): HlsMediaPlaylist {
+        val initSegment = segments
+            .firstOrNull { it.initializationSegment != null }
+            ?.initializationSegment
+            ?.toInternalInitSegment(sourceUrl)
         return HlsMediaPlaylist(
             sourceUrl = sourceUrl,
-            targetDurationSeconds = targetDuration,
+            targetDurationSeconds = secondsOf(targetDurationUs),
             mediaSequence = mediaSequence,
-            segments = segments,
-            isEndList = isEndList,
+            segments = segments.map { it.toInternalSegment(sourceUrl) },
+            isEndList = hasEndTag,
             initSegment = initSegment,
-            hasEncryption = hasEncryption,
-            hasUnsupportedEncryption = hasUnsupportedEncryption,
-            hasDiscontinuity = hasDiscontinuity,
+            hasEncryption = hasAes128Encryption(),
+            hasUnsupportedEncryption = hasUnsupportedEncryption(),
+            hasDiscontinuity = hasDiscontinuity(),
         )
     }
 
-    private fun parseInitSegment(
-        sourceUrl: String,
-        value: String,
-        encryptionKey: HlsEncryptionKey?,
-    ): HlsInitSegment? {
-        val attributes = parseAttributes(value)
-        val uri = attributes["URI"] ?: return null
+    private fun ExoHlsSegment.toInternalSegment(sourceUrl: String): HlsSegment {
+        return HlsSegment(
+            url = resolveUrl(sourceUrl, url),
+            durationSeconds = secondsOf(durationUs),
+            title = title.ifBlank { null },
+            byteRange = byteRange(),
+            discontinuity = relativeDiscontinuitySequence > 0,
+            encryptionKey = encryptionKey(sourceUrl),
+        )
+    }
+
+    private fun ExoHlsSegment.toInternalInitSegment(sourceUrl: String): HlsInitSegment {
         return HlsInitSegment(
-            url = resolveUrl(sourceUrl, uri),
-            byteRange = attributes["BYTERANGE"]?.let { parseByteRange(it) },
-            encryptionKey = encryptionKey,
+            url = resolveUrl(sourceUrl, url),
+            byteRange = byteRange(),
+            encryptionKey = encryptionKey(sourceUrl),
         )
     }
 
-    private fun parseAttributes(value: String): Map<String, String> {
-        return splitAttributeList(value).mapNotNull { attribute ->
-            val key = attribute.substringBefore('=', "").trim()
-            if (key.isBlank()) {
-                null
+    private fun ExoHlsMediaPlaylist.hasAes128Encryption(): Boolean {
+        return segments.any { it.fullSegmentEncryptionKeyUri != null }
+            || segments.any { it.initializationSegment?.fullSegmentEncryptionKeyUri != null }
+    }
+
+    private fun ExoHlsMediaPlaylist.hasUnsupportedEncryption(): Boolean {
+        return protectionSchemes != null || tags.any { tag ->
+            if (!tag.startsWith(EXT_X_KEY)) {
+                false
             } else {
-                key.uppercase(Locale.US) to attribute.substringAfter('=', "").trim().trim('"')
-            }
-        }.toMap()
-    }
-
-    private fun splitAttributeList(value: String): List<String> {
-        val result = mutableListOf<String>()
-        val current = StringBuilder()
-        var quoted = false
-
-        for (char in value) {
-            when (char) {
-                '"' -> {
-                    quoted = !quoted
-                    current.append(char)
-                }
-                ',' -> if (quoted) {
-                    current.append(char)
-                } else {
-                    result += current.toString()
-                    current.setLength(0)
-                }
-                else -> current.append(char)
+                val method = keyMethod(tag)
+                method != null
+                    && !method.equals("NONE", ignoreCase = true)
+                    && !method.equals("AES-128", ignoreCase = true)
             }
         }
-
-        if (current.isNotEmpty()) {
-            result += current.toString()
-        }
-
-        return result
     }
 
-    private fun parseByteRange(value: String): HlsByteRange? {
-        val length = value.substringBefore('@').toLongOrNull() ?: return null
-        val offset = value.substringAfter('@', "").toLongOrNull()
-        return HlsByteRange(length, offset)
+    private fun ExoHlsMediaPlaylist.hasDiscontinuity(): Boolean {
+        return tags.any { it == EXT_X_DISCONTINUITY }
+            || segments.any { it.relativeDiscontinuitySequence > 0 }
+    }
+
+    private fun ExoHlsSegmentBase.byteRange(): HlsByteRange? {
+        if (byteRangeLength <= 0) {
+            return null
+        }
+        return HlsByteRange(byteRangeLength, byteRangeOffset.takeIf { it >= 0 })
+    }
+
+    private fun ExoHlsSegmentBase.encryptionKey(sourceUrl: String): HlsEncryptionKey? {
+        val keyUri = fullSegmentEncryptionKeyUri ?: return null
+        return HlsEncryptionKey(
+            method = "AES-128",
+            url = resolveUrl(sourceUrl, keyUri),
+            iv = encryptionIV,
+        )
+    }
+
+    private fun keyMethod(tag: String): String? {
+        return Regex("(?:^|,)METHOD=([^,]+)")
+            .find(tag.substringAfter(':', ""))
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.trim('"')
+    }
+
+    private fun resolutionOf(format: Format): String? {
+        return if (format.width > 0 && format.height > 0) {
+            "${format.width}x${format.height}"
+        } else {
+            null
+        }
+    }
+
+    private fun positiveLong(value: Int): Long? {
+        return value.takeIf { it > 0 }?.toLong()
+    }
+
+    private fun secondsOf(valueUs: Long): Double? {
+        return valueUs.takeIf { it != C.TIME_UNSET && it >= 0 }?.let { it / 1_000_000.0 }
     }
 
     private fun resolveUrl(sourceUrl: String, reference: String): String {
         return URI(sourceUrl).resolve(reference).toString()
     }
 
-    private fun safeLineSnippet(line: String?): String {
-        return line
-            ?.take(80)
-            ?.map { char -> if (char.code in 32..126) char else '.' }
-            ?.joinToString(separator = "")
-            ?: "<none>"
-    }
-
     private companion object {
-        const val EXTM3U = "#EXTM3U"
-        const val EXTINF = "#EXTINF:"
-        const val EXT_X_STREAM_INF = "#EXT-X-STREAM-INF:"
-        const val EXT_X_TARGETDURATION = "#EXT-X-TARGETDURATION:"
-        const val EXT_X_MEDIA_SEQUENCE = "#EXT-X-MEDIA-SEQUENCE:"
-        const val EXT_X_BYTERANGE = "#EXT-X-BYTERANGE:"
-        const val EXT_X_MAP = "#EXT-X-MAP:"
         const val EXT_X_KEY = "#EXT-X-KEY:"
         const val EXT_X_DISCONTINUITY = "#EXT-X-DISCONTINUITY"
-        const val EXT_X_ENDLIST = "#EXT-X-ENDLIST"
     }
 }

--- a/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
+++ b/app/src/main/java/us/shandian/giga/service/DownloadManagerService.java
@@ -44,10 +44,10 @@ import org.schabi.newpipe.player.helper.LockManager;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Locale;
 import java.util.Objects;
 
 import us.shandian.giga.get.DownloadMission;
+import us.shandian.giga.get.HlsDownloadStreamHelper;
 import us.shandian.giga.get.MissionRecoveryInfo;
 import org.schabi.newpipe.streams.io.StoredDirectoryHelper;
 import org.schabi.newpipe.streams.io.StoredFileHelper;
@@ -451,7 +451,7 @@ public class DownloadManagerService extends Service {
         mission.resourceIsUrls = normalizeResourceBooleans(resourceIsUrls, urls);
 
         if (DEBUG && ps == null && urls != null && urls.length > 1
-                && !containsHlsResource(mission.resourceDeliveryMethods,
+                && !HlsDownloadStreamHelper.containsHlsResource(mission.resourceDeliveryMethods,
                 mission.resourceManifestUrls, urls)) {
             Log.w(TAG, "mission created with multiple urls ¿missing post-processing algorithm?");
         }
@@ -486,42 +486,6 @@ public class DownloadManagerService extends Service {
             values[i] = true;
         }
         return values;
-    }
-
-    private static boolean containsHlsMethod(String[] values) {
-        if (values == null) {
-            return false;
-        }
-        for (String value : values) {
-            if ("HLS".equals(value)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean containsHlsValue(String[] values) {
-        if (values == null) {
-            return false;
-        }
-        for (String value : values) {
-            if (looksLikeHls(value)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean containsHlsResource(String[] deliveryMethods,
-                                               String[] manifestUrls,
-                                               String[] urls) {
-        return containsHlsMethod(deliveryMethods)
-                || containsHlsValue(manifestUrls)
-                || containsHlsValue(urls);
-    }
-
-    private static boolean looksLikeHls(String value) {
-        return value != null && value.toLowerCase(Locale.ROOT).contains(".m3u8");
     }
 
     public void notifyFinishedDownload(String name) {


### PR DESCRIPTION
Follow-up after #38.

This is the cleanup discussed in the review thread after the HLS downloader merge.

Related:
- [PipePipe#2288 - Video Download Failure if logged in (YouTube)](https://github.com/InfinityLoop1308/PipePipe/issues/2288)
- [PipePipe#2206 - Can't download YouTube videos when signed into YouTube](https://github.com/InfinityLoop1308/PipePipe/issues/2206)

## Summary

This PR keeps the HLS downloader behavior from #38, but cleans up the code around it.

Changes:
- Replace the local HLS playlist parser with ExoPlayer's `HlsPlaylistParser`.
- Keep the current internal HLS models and map ExoPlayer playlist data into them.
- Move HLS detection/resource metadata into `HlsDownloadStreamHelper`.
- Reuse the helper from `DownloadDialog`, `DirectDownloader`, `DownloadMission`, `DownloadManagerService` and `HlsDownloader`.
- Keep direct/DASH/BiliBili downloads on the existing downloader path.

## Why

The first HLS PR added the missing download path, but some HLS-specific logic was still duplicated between multiple downloader classes.

This cleanup makes the HLS routing more explicit and easier to maintain without changing the normal direct/DASH download behavior.

## Extra fix found while testing

While testing the external/share route, I found that `Download` could still open `DownloadDialog` for live streams.

The normal detail page already avoids exposing download for live streams, but this router path did not. This PR now rejects live streams before opening the dialog.

I kept this fix here because it is in the same download routing path and the change is small.

## Implementation notes

The internal HLS models are still kept.

So the parser change is not a rewrite of the downloader model. ExoPlayer parses the HLS playlist, then PipePipe maps the parsed data into the existing HLS download models.

The existing legacy downloader path is still used for normal direct downloads and service-specific cases.

## Validation

Build:

- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk ./gradlew :app:compileDebugKotlin :app:compileDebugJavaWithJavac --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk ./gradlew :app:assembleDebug --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`
- `JAVA_HOME=/usr/lib/jvm/java-11-openjdk ./gradlew :app:testDebugUnitTest --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`

Device:

- Installed debug APK on Pixel 8.
- Tested logged-in YouTube HLS download + remux.
- Tested NicoNico HLS download + remux.
- Tested BiliBili direct/legacy download and confirmed it does not use the HLS path.
- Tested YouTube HLS pause/resume on emulator.
- Tested YouTube HLS recovery after force-stop on emulator.
- Tested YouTube live stream external/share `Download` route on Pixel 8 and emulator.
- Confirmed the live route does not open `DownloadDialog` and does not start a download mission.
