### PR TITLE
feat(download): support audio-only HLS downloads

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -174,6 +174,7 @@ public class DownloadDialog extends DialogFragment
 
         final List<AudioStream> downloadableAudio = ListHelper
                 .filterDownloadableAudioStreams(info.getAudioStreams());
+        HlsDownloadStreamHelper.addAudioFallbackIfNeeded(downloadableAudio, info);
 
         final DownloadDialog instance = newInstance(info);
         instance.setVideoStreams(filteredVideoStreams);
@@ -326,7 +327,7 @@ public class DownloadDialog extends DialogFragment
         dialogBinding.fileName.setText(FilenameUtils.createFilename(getContext(),
                 currentInfo.getName()));
         selectedAudioIndex = ListHelper
-                .getDefaultAudioFormat(getContext(), currentInfo.getAudioStreams());
+                .getDefaultAudioFormat(getContext(), wrappedAudioStreams.getStreamsList());
 
         selectedSubtitleIndex = getSubtitleIndexBy(subtitleStreamsAdapter.getAll());
 

--- a/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/ListHelper.java
@@ -935,7 +935,7 @@ public final class ListHelper {
             final List<AudioStream> audioStreams) {
         final List<AudioStream> result = new ArrayList<>();
         for (final AudioStream a : audioStreams) {
-            if (a.getDeliveryMethod() != DeliveryMethod.HLS || a.getAudioTrackId() == null) {
+            if (a.getDeliveryMethod() != DeliveryMethod.HLS || a.isUrl()) {
                 result.add(a);
             }
         }

--- a/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
+++ b/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
@@ -62,7 +62,10 @@ public class DirectDownloader {
 
         this.setVideoStreams(filteredVideoStreams);
         this.setSelectedVideoStream(selectedStreamIndex >= 0 ? selectedStreamIndex : 0);
-        this.setAudioStreams(ListHelper.filterDownloadableAudioStreams(info.getAudioStreams()));
+        final List<AudioStream> downloadableAudio = ListHelper
+                .filterDownloadableAudioStreams(info.getAudioStreams());
+        HlsDownloadStreamHelper.addAudioFallbackIfNeeded(downloadableAudio, info);
+        this.setAudioStreams(downloadableAudio);
         this.setInfo(info);
         this.type = type;
         this.context = context;

--- a/app/src/main/java/us/shandian/giga/get/DownloadMissionRecover.java
+++ b/app/src/main/java/us/shandian/giga/get/DownloadMissionRecover.java
@@ -141,10 +141,15 @@ public class DownloadMissionRecover extends Thread {
         switch (mRecovery.getKind()) {
             case 'a':
                 for (AudioStream audio : mExtractor.getAudioStreams()) {
-                    if (audio.getAverageBitrate() == mRecovery.getDesiredBitrate() && audio.getFormat() == mRecovery.getFormat()) {
+                    if (matchesAudioRecovery(audio)) {
                         resolvedStream = audio;
                         break;
                     }
+                }
+                if (resolvedStream == null && mRecovery.isHls()) {
+                    resolvedStream = HlsDownloadStreamHelper.createAudioFallback(
+                            mExtractor.getVideoStreams(), mExtractor.getHlsUrl(),
+                            mRecovery.getAudioTrackId());
                 }
                 break;
             case 'v':
@@ -223,6 +228,22 @@ public class DownloadMissionRecover extends Thread {
         } finally {
             disconnect();
         }
+    }
+
+    private boolean matchesAudioRecovery(final AudioStream audio) {
+        if (audio.getFormat() != mRecovery.getFormat()) {
+            return false;
+        }
+
+        if (mRecovery.isHls()) {
+            if (audio.getDeliveryMethod() != org.schabi.newpipe.extractor.stream.DeliveryMethod.HLS) {
+                return false;
+            }
+            final String audioTrackId = mRecovery.getAudioTrackId();
+            return audioTrackId == null || audioTrackId.equals(audio.getAudioTrackId());
+        }
+
+        return audio.getAverageBitrate() == mRecovery.getDesiredBitrate();
     }
 
     private void recover(Stream stream, boolean stale) {

--- a/app/src/main/java/us/shandian/giga/get/HlsDownloadStreamHelper.java
+++ b/app/src/main/java/us/shandian/giga/get/HlsDownloadStreamHelper.java
@@ -1,6 +1,7 @@
 package us.shandian.giga.get;
 
 import org.schabi.newpipe.extractor.MediaFormat;
+import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.DeliveryMethod;
 import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
@@ -14,6 +15,7 @@ public final class HlsDownloadStreamHelper {
     public static final String HLS_MANIFEST_RESOLUTION = "HLS";
 
     private static final String HLS_MANIFEST_STREAM_ID = "hls-manifest";
+    private static final String HLS_AUDIO_FALLBACK_STREAM_ID = "hls-audio-fallback";
     private static final String HLS_MANIFEST_CODEC = "hls";
 
     private HlsDownloadStreamHelper() {
@@ -33,6 +35,59 @@ public final class HlsDownloadStreamHelper {
 
         streams.add(createManifestFallback(hlsUrl));
         return true;
+    }
+
+    public static boolean addAudioFallbackIfNeeded(final List<AudioStream> streams,
+                                                   final StreamInfo info) {
+        if (streams == null || info == null || info.getStreamType() != StreamType.VIDEO_STREAM
+                || !streams.isEmpty()) {
+            return false;
+        }
+
+        final AudioStream fallback = createAudioFallback(info.getVideoStreams(), info.getHlsUrl(),
+                null);
+        if (fallback == null) {
+            return false;
+        }
+
+        streams.add(fallback);
+        return true;
+    }
+
+    public static AudioStream createAudioFallback(final List<VideoStream> streams,
+                                                  final String hlsUrl,
+                                                  final String audioTrackId) {
+        final VideoStream source = findAudioFallbackSource(streams, audioTrackId);
+        if (source != null) {
+            final String manifestUrl = source.getManifestUrl() != null
+                    ? source.getManifestUrl() : source.getContent();
+            return new AudioStream.Builder()
+                    .setId(HLS_AUDIO_FALLBACK_STREAM_ID + "-" + source.getId())
+                    .setContent(source.getContent(), true)
+                    .setMediaFormat(MediaFormat.M4A)
+                    .setDeliveryMethod(DeliveryMethod.HLS)
+                    .setManifestUrl(manifestUrl)
+                    .setAverageBitrate(AudioStream.UNKNOWN_BITRATE)
+                    .setQuality(HLS_MANIFEST_RESOLUTION)
+                    .setAudioTrackId(source.getAudioTrackId())
+                    .setAudioTrackName(source.getAudioTrackName())
+                    .setAudioLocale(source.getAudioLocale())
+                    .build();
+        }
+
+        if (hlsUrl == null || hlsUrl.isEmpty()) {
+            return null;
+        }
+
+        return new AudioStream.Builder()
+                .setId(HLS_AUDIO_FALLBACK_STREAM_ID)
+                .setContent(hlsUrl, true)
+                .setMediaFormat(MediaFormat.M4A)
+                .setDeliveryMethod(DeliveryMethod.HLS)
+                .setManifestUrl(hlsUrl)
+                .setAverageBitrate(AudioStream.UNKNOWN_BITRATE)
+                .setQuality(HLS_MANIFEST_RESOLUTION)
+                .build();
     }
 
     public static VideoStream createManifestFallback(final String hlsUrl) {
@@ -113,6 +168,60 @@ public final class HlsDownloadStreamHelper {
             }
         }
         return false;
+    }
+
+    private static VideoStream findAudioFallbackSource(final List<VideoStream> streams,
+                                                       final String audioTrackId) {
+        if (streams == null) {
+            return null;
+        }
+
+        VideoStream best = null;
+        for (final VideoStream stream : streams) {
+            if (stream.getDeliveryMethod() != DeliveryMethod.HLS || stream.isVideoOnly()
+                    || !stream.isUrl()) {
+                continue;
+            }
+            if (audioTrackId != null && !audioTrackId.equals(stream.getAudioTrackId())) {
+                continue;
+            }
+            if (best == null || isSmallerVariant(stream, best)) {
+                best = stream;
+            }
+        }
+        return best;
+    }
+
+    private static boolean isSmallerVariant(final VideoStream candidate,
+                                            final VideoStream existing) {
+        final int candidateHeight = heightOf(candidate.getResolution());
+        final int existingHeight = heightOf(existing.getResolution());
+        if (candidateHeight != existingHeight) {
+            return candidateHeight < existingHeight;
+        }
+
+        final int candidateBitrate = candidate.getBitrate();
+        final int existingBitrate = existing.getBitrate();
+        return candidateBitrate > 0 && (existingBitrate <= 0 || candidateBitrate < existingBitrate);
+    }
+
+    private static int heightOf(final String resolution) {
+        if (resolution == null) {
+            return Integer.MAX_VALUE;
+        }
+        final int pIndex = resolution.toLowerCase(Locale.ROOT).indexOf('p');
+        if (pIndex <= 0) {
+            return Integer.MAX_VALUE;
+        }
+        int start = pIndex - 1;
+        while (start > 0 && Character.isDigit(resolution.charAt(start - 1))) {
+            start--;
+        }
+        try {
+            return Integer.parseInt(resolution.substring(start, pIndex));
+        } catch (final NumberFormatException ignored) {
+            return Integer.MAX_VALUE;
+        }
     }
 
     private static boolean containsHlsMethod(final String[] values) {

--- a/app/src/main/java/us/shandian/giga/get/HlsDownloader.kt
+++ b/app/src/main/java/us/shandian/giga/get/HlsDownloader.kt
@@ -218,7 +218,9 @@ internal class HlsDownloader(
             inputs.forEach { input ->
                 append("-i ").append(quote(input.absolutePath)).append(' ')
             }
-            if (inputs.size > 1) {
+            if (mission.kind == 'a' && inputs.size == 1) {
+                append("-map 0:a? -vn ")
+            } else if (inputs.size > 1) {
                 inputs.indices.forEach { index ->
                     append("-map ").append(index).append(":v? ")
                     append("-map ").append(index).append(":a? ")

--- a/app/src/main/java/us/shandian/giga/get/MissionRecoveryInfo.kt
+++ b/app/src/main/java/us/shandian/giga/get/MissionRecoveryInfo.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 import org.schabi.newpipe.extractor.MediaFormat
 import org.schabi.newpipe.extractor.stream.AudioStream
+import org.schabi.newpipe.extractor.stream.DeliveryMethod
 import org.schabi.newpipe.extractor.stream.Stream
 import org.schabi.newpipe.extractor.stream.SubtitlesStream
 import org.schabi.newpipe.extractor.stream.VideoStream
@@ -16,19 +17,24 @@ class MissionRecoveryInfo(
     var isDesired2: Boolean = false,
     var desiredBitrate: Int = 0,
     var kind: Char = Char.MIN_VALUE,
-    var validateCondition: String? = null
+    var validateCondition: String? = null,
+    var audioTrackId: String? = null,
+    var isHls: Boolean = false
 ) : Serializable, Parcelable {
     constructor(stream: Stream) : this(format = stream.getFormat()!!) {
+        isHls = stream.getDeliveryMethod() == DeliveryMethod.HLS
         when (stream) {
             is AudioStream -> {
                 desiredBitrate = stream.averageBitrate
                 isDesired2 = false
                 kind = 'a'
+                audioTrackId = stream.audioTrackId
             }
             is VideoStream -> {
                 desired = stream.resolution
                 isDesired2 = stream.isVideoOnly
                 kind = 'v'
+                audioTrackId = stream.audioTrackId
             }
             is SubtitlesStream -> {
                 desired = stream.languageTag


### PR DESCRIPTION
Follow-up after #38 and #40.

This adds the audio-only HLS download path discussed after the first HLS downloader PR.

Related:
- #38
- #40
- [PipePipe#2206 - Can't download YouTube videos when signed into YouTube](https://github.com/InfinityLoop1308/PipePipe/issues/2206)

## Summary

This PR lets the download dialog expose and download audio-only HLS streams.

Before this change, HLS video downloads worked, but the audio tab could still have no usable downloadable stream for the same video.

This plugs HLS audio into the existing audio download flow and routes it through `HlsDownloader`.

## Changes

- Allow URL-based HLS audio streams in the downloadable audio list.
- Keep non-URL/inline HLS audio streams hidden because the HLS downloader does not support them.
- Add an audio fallback from the smallest HLS video+audio variant when no separate audio stream is exposed.
- Use the fallback in both `DownloadDialog` and `DirectDownloader`.
- Remux single-resource audio HLS downloads with audio-only ffmpeg mapping.
- Store HLS/audio track metadata in `MissionRecoveryInfo`.
- Recover HLS audio downloads by matching format, HLS state and audio track id when available.
- Keep direct/DASH/BiliBili downloads on the existing downloader path.

## Why

The HLS video download path landed in #38, then the routing/parser cleanup landed in #40.

This keeps the same split and adds the audio-only HLS path separately, so the normal direct/DASH download behavior stays untouched.

## Validation

Build:
- `./gradlew :app:compileDebugKotlin :app:compileDebugJavaWithJavac --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`
- `./gradlew :app:testDebugUnitTest --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`
- `./gradlew :app:assembleDebug --no-daemon --no-build-cache --no-configuration-cache --max-workers=1 --stacktrace`

Device/emulator:
- Tested YouTube HLS audio-only download on emulator.
- Tested YouTube HLS video download still works on emulator.
- Tested HLS audio recovery after interruption on emulator.
- Tested BiliBili legacy video download and confirmed it does not use the HLS path.
- Tested BiliBili direct audio download and confirmed it does not use the HLS path.
- Tested YouTube live stream download route still does not start an unsupported mission.
- Installed debug APK on Pixel 8.
- Tested YouTube HLS audio-only download from the visible download dialog on Pixel 8.
- Tested YouTube HLS video download from the visible download dialog on Pixel 8.
- Tested BiliBili video/audio regression paths from the visible download dialog on Pixel 8.
