### PR TITLE
SABR playback support (client side, PoC)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -500,6 +500,10 @@
         <activity android:name=".views.BiliBiliLoginWebViewActivity"
                   android:configChanges="orientation|screenSize"
                   android:theme="@style/Theme.AppCompat.NoActionBar" />
+        <activity android:name=".views.SabrPoTokenPocActivity"
+                  android:exported="true"
+                  android:configChanges="orientation|screenSize"
+                  android:theme="@style/Theme.AppCompat.NoActionBar" />
 
         <activity
                 android:name=".settings.KeywordFilterListActivity"

--- a/app/src/main/assets/sabr_potoken_poc.js
+++ b/app/src/main/assets/sabr_potoken_poc.js
@@ -1,0 +1,301 @@
+/*
+ * SABR PO token POC — WebView pipeline (att mode).
+ *
+ * Ported from the local research mint (mint-po-token-browser.mjs), adapted to run inside an Android
+ * WebView instead of puppeteer. It must be injected AFTER https://www.youtube.com/ has finished
+ * loading (same-origin is required: att/get and GenerateIT are youtube.com endpoints, and the
+ * BotGuard interpreter is embedded in the challenge).
+ *
+ * Flow: read browser context -> att/get challenge -> run BotGuard VM -> snapshot -> GenerateIT
+ * integrity token -> mint a videoId-bound PO token -> hand the result back through the
+ * `SabrPocBridge` JavascriptInterface.
+ *
+ * INTERNAL / LOCAL POC ONLY. The minted PO token is session-bound; keep it out of any public log.
+ * API_KEY / REQUEST_KEY are the well-known public ecosystem constants, not secrets.
+ */
+(function () {
+    'use strict';
+
+    // YouTube ships a Trusted Types CSP (require-trusted-types-for 'script') that blocks
+    // new Function()/eval of the BotGuard interpreter. Installing an identity "default" policy makes
+    // Chromium route those sinks through it, restoring dynamic evaluation. If the CSP forbids
+    // creating the policy, loadBotGuard() will surface the eval error instead.
+    try {
+        if (window.trustedTypes && window.trustedTypes.createPolicy
+                && !window.trustedTypes.defaultPolicy) {
+            window.trustedTypes.createPolicy('default', {
+                createHTML: function (value) { return value; },
+                createScript: function (value) { return value; },
+                createScriptURL: function (value) { return value; }
+            });
+        }
+    } catch (ttError) {
+        // ignore; surfaced later as an eval failure
+    }
+
+    var API_KEY = 'AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw';
+    var REQUEST_KEY = 'O43z0dpjhgX20SCx4KAo';
+
+    function report(result) {
+        try {
+            // eslint-disable-next-line no-undef
+            SabrPocBridge.onResult(JSON.stringify(result));
+        } catch (e) {
+            // Bridge not present (e.g. plain browser run): fall back to console.
+            try {
+                console.log('[sabr-poc] ' + JSON.stringify(result));
+            } catch (ignored) {
+                // nothing else we can do
+            }
+        }
+    }
+
+    function step(message) {
+        try { console.log('[sabr-poc] ' + message); } catch (e) { /* ignore */ }
+    }
+
+    function readVisitorData() {
+        var cfg = window.ytcfg;
+        var fromCfg = cfg && typeof cfg.get === 'function' ? cfg.get('VISITOR_DATA') : null;
+        if (fromCfg) {
+            return fromCfg;
+        }
+        var html = document.documentElement.innerHTML;
+        var marker = '"VISITOR_DATA":"';
+        var start = html.indexOf(marker);
+        if (start < 0) {
+            throw new Error('Could not find visitor data');
+        }
+        var from = start + marker.length;
+        var end = html.indexOf('"', from);
+        if (end < 0) {
+            throw new Error('Could not find visitor data end');
+        }
+        return html.slice(from, end);
+    }
+
+    function readClientVersion() {
+        var cfg = window.ytcfg;
+        var fromCfg = cfg && typeof cfg.get === 'function'
+            ? cfg.get('INNERTUBE_CLIENT_VERSION') : null;
+        return fromCfg || '2.20260114.01.00';
+    }
+
+    function normalizeTrustedUrl(value) {
+        if (!value) {
+            throw new Error('Missing interpreter url');
+        }
+        return value.indexOf('//') === 0 ? 'https:' + value : value;
+    }
+
+    function fetchChallenge(ctx) {
+        var context = {
+            client: {
+                clientName: 'WEB',
+                clientVersion: ctx.clientVersion,
+                hl: 'en',
+                gl: 'US',
+                utcOffsetMinutes: 0,
+                visitorData: ctx.visitorData
+            }
+        };
+        return fetch('https://www.youtube.com/youtubei/v1/att/get?prettyPrint=false&alt=json', {
+            method: 'POST',
+            headers: {
+                'Accept': '*/*',
+                'Content-Type': 'application/json',
+                'X-Goog-Visitor-Id': ctx.visitorData,
+                'X-Youtube-Client-Version': ctx.clientVersion,
+                'X-Youtube-Client-Name': '1'
+            },
+            body: JSON.stringify({
+                engagementType: 'ENGAGEMENT_TYPE_UNBOUND',
+                context: context
+            })
+        }).then(function (response) {
+            return response.json().then(function (data) {
+                if (!response.ok || !data.bgChallenge) {
+                    throw new Error('att/get failed status=' + response.status);
+                }
+                return data.bgChallenge;
+            });
+        });
+    }
+
+    function resolveInterpreter(challenge, userAgent) {
+        var embedded = challenge.interpreterJavascript
+            && challenge.interpreterJavascript.privateDoNotAccessOrElseSafeScriptWrappedValue;
+        if (embedded) {
+            return Promise.resolve(embedded);
+        }
+        var url = normalizeTrustedUrl(
+            (challenge.interpreterJavascript
+                && challenge.interpreterJavascript
+                    .privateDoNotAccessOrElseTrustedResourceUrlWrappedValue)
+            || (challenge.interpreterUrl
+                && challenge.interpreterUrl
+                    .privateDoNotAccessOrElseTrustedResourceUrlWrappedValue));
+        return fetch(url, { headers: { 'User-Agent': userAgent } }).then(function (response) {
+            return response.text().then(function (js) {
+                if (!response.ok || !js) {
+                    throw new Error('interpreter fetch failed status=' + response.status);
+                }
+                return js;
+            });
+        });
+    }
+
+    function loadBotGuard(interpreterJavascript, program, globalName) {
+        return new Promise(function (resolve, reject) {
+            try {
+                new Function(interpreterJavascript)();
+            } catch (e) {
+                reject(new Error('interpreter eval failed: ' + e.message));
+                return;
+            }
+            var vm = window[globalName];
+            if (!vm || typeof vm.a !== 'function') {
+                reject(new Error('BotGuard VM missing init function'));
+                return;
+            }
+            var timeout = setTimeout(function () {
+                reject(new Error('BotGuard init timeout'));
+            }, 10000);
+            try {
+                vm.a(program, function (asyncSnapshotFunction) {
+                    clearTimeout(timeout);
+                    resolve({ asyncSnapshotFunction: asyncSnapshotFunction });
+                }, true, undefined, function () { }, [[], []]);
+            } catch (e) {
+                clearTimeout(timeout);
+                reject(new Error('BotGuard init threw: ' + e.message));
+            }
+        });
+    }
+
+    function snapshot(functions, webPoSignalOutput) {
+        return new Promise(function (resolve, reject) {
+            var timeout = setTimeout(function () {
+                reject(new Error('BotGuard snapshot timeout'));
+            }, 10000);
+            functions.asyncSnapshotFunction(function (response) {
+                clearTimeout(timeout);
+                resolve(response);
+            }, [undefined, undefined, webPoSignalOutput, undefined]);
+        });
+    }
+
+    function fetchIntegrityToken(botGuardResponse, userAgent) {
+        return fetch('https://www.youtube.com/api/jnn/v1/GenerateIT', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json+protobuf',
+                'x-goog-api-key': API_KEY,
+                'x-user-agent': 'grpc-web-javascript/0.1',
+                'User-Agent': userAgent
+            },
+            body: JSON.stringify([REQUEST_KEY, botGuardResponse])
+        }).then(function (response) {
+            return response.json().then(function (data) {
+                var integrityToken = data[0];
+                if (typeof integrityToken !== 'string') {
+                    throw new Error('GenerateIT failed status=' + response.status);
+                }
+                return integrityToken;
+            });
+        });
+    }
+
+    function base64ToU8(value) {
+        var normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+        var padded = normalized + '==='.slice((normalized.length + 3) % 4);
+        var binary = atob(padded);
+        var bytes = new Uint8Array(binary.length);
+        for (var i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    }
+
+    function u8ToBase64Url(value) {
+        var binary = '';
+        for (var i = 0; i < value.length; i++) {
+            binary += String.fromCharCode(value[i]);
+        }
+        return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+    }
+
+    function mint(webPoSignalOutput, integrityToken, identifier) {
+        var getMinter = webPoSignalOutput[0];
+        if (typeof getMinter !== 'function') {
+            return Promise.reject(new Error('Missing PO minter factory'));
+        }
+        return Promise.resolve(getMinter(base64ToU8(integrityToken))).then(function (mintCallback) {
+            if (typeof mintCallback !== 'function') {
+                throw new Error('Missing PO mint callback');
+            }
+            return Promise.resolve(mintCallback(new TextEncoder().encode(identifier)))
+                .then(u8ToBase64Url);
+        });
+    }
+
+    function run() {
+        step('run start, readyState=' + document.readyState + ' origin=' + location.origin);
+        var videoId = window.__SABR_POC_VIDEO_ID || 'aqz-KE-bpKQ';
+        var ctx = {
+            visitorData: readVisitorData(),
+            clientVersion: readClientVersion(),
+            userAgent: navigator.userAgent
+        };
+        step('context ok visitorLen=' + ctx.visitorData.length + ' clientVersion=' + ctx.clientVersion);
+        var webPoSignalOutput = [];
+        var integrityTokenLength = -1;
+        step('fetching att/get challenge...');
+        return fetchChallenge(ctx).then(function (challenge) {
+            step('challenge ok embedded='
+                + !!(challenge.interpreterJavascript
+                    && challenge.interpreterJavascript.privateDoNotAccessOrElseSafeScriptWrappedValue));
+            return resolveInterpreter(challenge, ctx.userAgent).then(function (interpreterJs) {
+                step('interpreter resolved len=' + (interpreterJs ? interpreterJs.length : -1));
+                return loadBotGuard(interpreterJs, challenge.program, challenge.globalName);
+            });
+        }).then(function (functions) {
+            step('botguard loaded, taking snapshot...');
+            return snapshot(functions, webPoSignalOutput);
+        }).then(function (botGuardResponse) {
+            step('snapshot ok, calling GenerateIT...');
+            return fetchIntegrityToken(botGuardResponse, ctx.userAgent);
+        }).then(function (integrityToken) {
+            step('integrity token len=' + integrityToken.length + ', minting...');
+            integrityTokenLength = integrityToken.length;
+            return mint(webPoSignalOutput, integrityToken, videoId);
+        }).then(function (poToken) {
+            report({
+                ok: true,
+                videoId: videoId,
+                clientVersion: ctx.clientVersion,
+                visitorDataLength: ctx.visitorData.length,
+                integrityTokenLength: integrityTokenLength,
+                poTokenLength: poToken.length,
+                poToken: poToken,
+                userAgent: ctx.userAgent
+            });
+        });
+    }
+
+    function reportError(e) {
+        report({
+            ok: false,
+            error: (e && e.message) ? e.message : String(e),
+            errorName: e && e.name ? e.name : '',
+            stack: e && e.stack ? String(e.stack).slice(0, 400) : '',
+            userAgent: navigator.userAgent
+        });
+    }
+
+    try {
+        run().catch(reportError);
+    } catch (e) {
+        reportError(e);
+    }
+})();

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -130,6 +130,7 @@ import org.schabi.newpipe.player.helper.LoadController;
 import org.schabi.newpipe.player.helper.MediaSessionManager;
 import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.helper.PlayerHelper;
+import org.schabi.newpipe.player.datasource.SabrSessionStore;
 import org.schabi.newpipe.player.listeners.view.PlaybackSpeedClickListener;
 import org.schabi.newpipe.player.listeners.view.QualityClickListener;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
@@ -1775,6 +1776,10 @@ public final class Player implements
         if (!isPrepared) {
             return;
         }
+
+        // Feed the real play head to any live SABR session (no-op otherwise).
+        getCurrentStreamInfo().ifPresent(info ->
+                SabrSessionStore.updatePlayerTime(info.getId(), currentProgress));
 
         if (duration != binding.playbackSeekBar.getMax()) {
             setVideoDurationToControls(duration);
@@ -3996,13 +4001,19 @@ public final class Player implements
 
         for (int i = 0; i < availableStreams.size(); i++) {
             final VideoStream videoStream = availableStreams.get(i);
-            qualityPopupMenu.getMenu().add(POPUP_MENU_ID_QUALITY, i, Menu.NONE, videoStream.getCodec().toUpperCase().split("\\.")[0] + " " + videoStream.resolution);
+            qualityPopupMenu.getMenu().add(POPUP_MENU_ID_QUALITY, i, Menu.NONE, videoStream.getCodec().toUpperCase().split("\\.")[0] + " " + videoStream.resolution + sabrTag(videoStream));
         }
         if (getSelectedVideoStream() != null) {
-            binding.qualityTextView.setText(getSelectedVideoStream().resolution);
+            binding.qualityTextView.setText(getSelectedVideoStream().resolution + sabrTag(getSelectedVideoStream()));
         }
         qualityPopupMenu.setOnMenuItemClickListener(this);
         qualityPopupMenu.setOnDismissListener(this);
+    }
+
+    // PoC marker: flag SABR-delivered streams in the quality UI
+    private static String sabrTag(final VideoStream stream) {
+        return stream != null && stream.getDeliveryMethod() == DeliveryMethod.SABR
+                ? " (SABR)" : "";
     }
 
     private void buildPlaybackSpeedMenu() {
@@ -4144,7 +4155,7 @@ public final class Player implements
         }
         isSomePopupMenuVisible = false; //TODO check if this works
         if (getSelectedVideoStream() != null) {
-            binding.qualityTextView.setText(getSelectedVideoStream().resolution);
+            binding.qualityTextView.setText(getSelectedVideoStream().resolution + sabrTag(getSelectedVideoStream()));
         }
         if (isPlaying()) {
             hideControls(DEFAULT_CONTROLS_DURATION, 0);

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3298,7 +3298,34 @@ public final class Player implements
     }
 
     public boolean shouldSeek() {
+        // our v1 SABR seek is a dumb byte-skip that can't land on a real position, so resuming
+        // mid-video just freezes the whole thing. so SABR always starts from 0, scrubbing can wait.
+        // honestly nobody died from rewatching an intro. plays fine from 0.
+        if (isCurrentStreamSabr()) {
+            return false;
+        }
         return !prefs.getBoolean(context.getString(R.string.always_start_from_beginning_key), false);
+    }
+
+    private boolean isCurrentStreamSabr() {
+        return getCurrentStreamInfo().map(info -> {
+            for (final VideoStream s : info.getVideoOnlyStreams()) {
+                if (s.getDeliveryMethod() == DeliveryMethod.SABR) {
+                    return true;
+                }
+            }
+            for (final VideoStream s : info.getVideoStreams()) {
+                if (s.getDeliveryMethod() == DeliveryMethod.SABR) {
+                    return true;
+                }
+            }
+            for (final AudioStream s : info.getAudioStreams()) {
+                if (s.getDeliveryMethod() == DeliveryMethod.SABR) {
+                    return true;
+                }
+            }
+            return false;
+        }).orElse(false);
     }
 
     public void seekTo(final long positionMillis) {

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
@@ -1,0 +1,211 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import com.google.android.exoplayer2.C;
+import com.google.android.exoplayer2.upstream.DataSource;
+import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.upstream.TransferListener;
+
+import org.schabi.newpipe.extractor.localization.Localization;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrMediaSegment;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrSegmentRequest;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrFormat;
+
+import java.io.IOException;
+
+/**
+ * ExoPlayer {@link DataSource} exposing one SABR format (audio or video) as a continuous byte
+ * stream: init segment then media segments. It only reads the session's concurrent cache, which a
+ * single {@link SabrStreamPump} fills ahead of the play head; so the two data sources never touch
+ * the network nor block each other. We end the stream past the last segment, on a pump fatal error,
+ * or if the play head stays frozen long enough to call it a genuine stall.
+ *
+ * <p>v1: sequential read from the start, seeks skip forward, length unknown until end-of-stream.</p>
+ */
+public final class SabrDataSource implements DataSource {
+
+    private static final String TAG = "SabrDataSource";
+
+    private static final long WAIT_MS = 250;
+    // Give up (so ExoPlayer re-opens us, which unsticks the SABR flow) only when the pump has pulled
+    // NO segment for a while. Be patient before playback ever starts — cold start blocks on the
+    // WebView PO-token mint with no segments — and a real underrun usually recovers as the pump
+    // catches up. We deliberately do NOT EOF early on a stall: signalling EOF makes ExoPlayer
+    // re-open at a byte offset, and the v1 byte-skip seek corrupts the fragmented container (frozen
+    // video). So we wait through stalls and only give up if the pump is truly dry for a long time.
+    private static final long STALL_MS = 120_000;
+
+    private final SabrSessionStore.Holder holder;
+    private final YoutubeSabrFormat format;
+    private final Localization localization;
+
+    @Nullable
+    private Uri uri;
+    @Nullable
+    private byte[] current;
+    private int currentPos;
+    private boolean initServed;
+    private int nextSeq;
+    private boolean ended;
+    private long skipRemaining;
+    private volatile boolean canceled;
+
+    public SabrDataSource(final SabrSessionStore.Holder holder,
+                          final YoutubeSabrFormat format,
+                          final Localization localization) {
+        this.holder = holder;
+        this.format = format;
+        this.localization = localization;
+    }
+
+    @Override
+    public void addTransferListener(final TransferListener transferListener) {
+        // Bandwidth metering not wired for the SABR v1 source.
+    }
+
+    @Override
+    public long open(final DataSpec dataSpec) {
+        this.uri = dataSpec.uri;
+        this.current = null;
+        this.currentPos = 0;
+        this.initServed = false;
+        this.nextSeq = 1; // SABR media sequence numbers are 1-based (0 is rejected)
+        this.ended = false;
+        this.skipRemaining = Math.max(0, dataSpec.position);
+        this.canceled = false;
+        return C.LENGTH_UNSET;
+    }
+
+    @Override
+    public int read(final byte[] target, final int offset, final int length) throws IOException {
+        if (length == 0) {
+            return 0;
+        }
+        if (ended) {
+            return C.RESULT_END_OF_INPUT;
+        }
+        // Drop bytes for a forward seek (v1 skips from the start).
+        while (skipRemaining > 0) {
+            if (!ensureBuffer()) {
+                return C.RESULT_END_OF_INPUT;
+            }
+            final int available = current.length - currentPos;
+            final int drop = (int) Math.min(available, skipRemaining);
+            currentPos += drop;
+            skipRemaining -= drop;
+        }
+        if (!ensureBuffer()) {
+            return C.RESULT_END_OF_INPUT;
+        }
+        final int available = current.length - currentPos;
+        final int toCopy = Math.min(length, available);
+        System.arraycopy(current, currentPos, target, offset, toCopy);
+        currentPos += toCopy;
+        return toCopy;
+    }
+
+    /**
+     * Make sure {@link #current} has unread bytes, waiting for the pump to cache the next segment.
+     *
+     * @return false if the stream is exhausted
+     */
+    private boolean ensureBuffer() throws IOException {
+        if (current != null && currentPos < current.length) {
+            return true;
+        }
+        final SabrStreamPump pump = holder.getPump(localization);
+        while (true) {
+            if (canceled) {
+                ended = true;
+                return false;
+            }
+            final SabrSegmentRequest request = initServed
+                    ? SabrSegmentRequest.media(format, nextSeq)
+                    : SabrSegmentRequest.initialization(format);
+            pump.ensureStarted();
+            final SabrMediaSegment segment = pump.getCached(request);
+            if (segment != null) {
+                if (initServed) {
+                    nextSeq++;
+                } else {
+                    initServed = true;
+                }
+                current = segment.getData();
+                currentPos = 0;
+                if (current.length == 0) {
+                    continue;
+                }
+                return true;
+            }
+            if (holder.isBeyondEnd(request)) {
+                ended = true;
+                return false;
+            }
+            if (pump.isFatal()) {
+                // Surface a real error (not a clean EOF) so ExoPlayer reports a playback error
+                // instead of pretending the video ended. The session was evicted on fatal, so a
+                // retry rebuilds a fresh one.
+                throw new IOException("SABR pump fatal for itag=" + format.getItag()
+                        + " at seq=" + nextSeq);
+            }
+            // Segment not cached yet: the pump is fetching or the server is pacing us. Wait — do
+            // NOT signal EOF here (it would trigger a corrupting re-open). Only give up if the pump
+            // has been fully dry (no segment for any track) long enough to be a genuine dead stall.
+            if (pump.millisSinceLastSegment() > STALL_MS) {
+                Log.i(TAG, "end of SABR stream (stalled) itag=" + format.getItag()
+                        + " at seq=" + nextSeq);
+                ended = true;
+                return false;
+            }
+            try {
+                Thread.sleep(WAIT_MS);
+            } catch (final InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                if (canceled) {
+                    ended = true;
+                    return false; // clean cancellation (close/seek/release), not a playback error
+                }
+                throw new IOException("Interrupted during SABR wait", ie);
+            }
+        }
+    }
+
+    @Nullable
+    @Override
+    public Uri getUri() {
+        return uri;
+    }
+
+    @Override
+    public void close() {
+        // Unblock a read() that is waiting for the pump (it polls this flag), so ExoPlayer can
+        // release this loader thread promptly on stop/seek/track-change.
+        canceled = true;
+        current = null;
+        currentPos = 0;
+    }
+
+    /** Factory binding a {@link SabrDataSource} to one shared session holder + format. */
+    public static final class Factory implements DataSource.Factory {
+        private final SabrSessionStore.Holder holder;
+        private final YoutubeSabrFormat format;
+        private final Localization localization;
+
+        public Factory(final SabrSessionStore.Holder holder,
+                       final YoutubeSabrFormat format,
+                       final Localization localization) {
+            this.holder = holder;
+            this.format = format;
+            this.localization = localization;
+        }
+
+        @Override
+        public DataSource createDataSource() {
+            return new SabrDataSource(holder, format, localization);
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
@@ -52,9 +52,6 @@ public final class SabrDataSource implements DataSource {
     private boolean ended;
     private long skipRemaining;
     private volatile boolean canceled;
-    // SABR-DIAG: avoid spamming the WAIT log every poll; only log when the awaited segment changes.
-    private int waitLoggedSeq = -2;
-    private boolean waitLoggedInit;
 
     public SabrDataSource(final SabrSessionStore.Holder holder,
                           final YoutubeSabrFormat format,
@@ -79,7 +76,6 @@ public final class SabrDataSource implements DataSource {
         this.ended = false;
         this.skipRemaining = Math.max(0, dataSpec.position);
         this.canceled = false;
-        Log.i(TAG, "SABR-DIAG open itag=" + format.getItag() + " pos=" + dataSpec.position);
         return C.LENGTH_UNSET;
     }
 
@@ -132,10 +128,6 @@ public final class SabrDataSource implements DataSource {
             pump.ensureStarted();
             final SabrMediaSegment segment = pump.getCached(request);
             if (segment != null) {
-                Log.i(TAG, "SABR-DIAG serve itag=" + format.getItag()
-                        + (request.isInitializationSegment()
-                                ? " init" : " seq=" + request.getSequenceNumber())
-                        + " len=" + segment.getLength());
                 if (initServed) {
                     nextSeq++;
                 } else {
@@ -148,15 +140,7 @@ public final class SabrDataSource implements DataSource {
                 }
                 return true;
             }
-            if (waitLoggedSeq != nextSeq || waitLoggedInit != initServed) {
-                waitLoggedSeq = nextSeq;
-                waitLoggedInit = initServed;
-                Log.i(TAG, "SABR-DIAG WAIT itag=" + format.getItag()
-                        + (initServed ? " want seq=" + nextSeq : " want init"));
-            }
             if (holder.isBeyondEnd(request)) {
-                Log.i(TAG, "SABR-DIAG EOF beyond-end itag=" + format.getItag()
-                        + " seq=" + nextSeq + " init=" + !initServed);
                 ended = true;
                 return false;
             }

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrDataSource.java
@@ -31,12 +31,11 @@ public final class SabrDataSource implements DataSource {
     private static final String TAG = "SabrDataSource";
 
     private static final long WAIT_MS = 250;
-    // Give up (so ExoPlayer re-opens us, which unsticks the SABR flow) only when the pump has pulled
-    // NO segment for a while. Be patient before playback ever starts — cold start blocks on the
-    // WebView PO-token mint with no segments — and a real underrun usually recovers as the pump
-    // catches up. We deliberately do NOT EOF early on a stall: signalling EOF makes ExoPlayer
-    // re-open at a byte offset, and the v1 byte-skip seek corrupts the fragmented container (frozen
-    // video). So we wait through stalls and only give up if the pump is truly dry for a long time.
+    // only bail once the pump's been dry a while (bailing makes ExoPlayer re-open us, which unsticks
+    // the flow). be patient at cold start: the ~45s WebView mint = zero segments for a bit, and most
+    // underruns just sort themselves out once the pump catches up.
+    // do NOT EOF early on a stall: ExoPlayer re-opens at a byte offset and our v1 byte-skip seek
+    // fucks the fragmented container = frozen video. so we just ride the stall out.
     private static final long STALL_MS = 120_000;
 
     private final SabrSessionStore.Holder holder;
@@ -53,6 +52,9 @@ public final class SabrDataSource implements DataSource {
     private boolean ended;
     private long skipRemaining;
     private volatile boolean canceled;
+    // SABR-DIAG: avoid spamming the WAIT log every poll; only log when the awaited segment changes.
+    private int waitLoggedSeq = -2;
+    private boolean waitLoggedInit;
 
     public SabrDataSource(final SabrSessionStore.Holder holder,
                           final YoutubeSabrFormat format,
@@ -77,6 +79,7 @@ public final class SabrDataSource implements DataSource {
         this.ended = false;
         this.skipRemaining = Math.max(0, dataSpec.position);
         this.canceled = false;
+        Log.i(TAG, "SABR-DIAG open itag=" + format.getItag() + " pos=" + dataSpec.position);
         return C.LENGTH_UNSET;
     }
 
@@ -129,6 +132,10 @@ public final class SabrDataSource implements DataSource {
             pump.ensureStarted();
             final SabrMediaSegment segment = pump.getCached(request);
             if (segment != null) {
+                Log.i(TAG, "SABR-DIAG serve itag=" + format.getItag()
+                        + (request.isInitializationSegment()
+                                ? " init" : " seq=" + request.getSequenceNumber())
+                        + " len=" + segment.getLength());
                 if (initServed) {
                     nextSeq++;
                 } else {
@@ -141,7 +148,15 @@ public final class SabrDataSource implements DataSource {
                 }
                 return true;
             }
+            if (waitLoggedSeq != nextSeq || waitLoggedInit != initServed) {
+                waitLoggedSeq = nextSeq;
+                waitLoggedInit = initServed;
+                Log.i(TAG, "SABR-DIAG WAIT itag=" + format.getItag()
+                        + (initServed ? " want seq=" + nextSeq : " want init"));
+            }
             if (holder.isBeyondEnd(request)) {
+                Log.i(TAG, "SABR-DIAG EOF beyond-end itag=" + format.getItag()
+                        + " seq=" + nextSeq + " init=" + !initServed);
                 ended = true;
                 return false;
             }
@@ -152,9 +167,9 @@ public final class SabrDataSource implements DataSource {
                 throw new IOException("SABR pump fatal for itag=" + format.getItag()
                         + " at seq=" + nextSeq);
             }
-            // Segment not cached yet: the pump is fetching or the server is pacing us. Wait — do
-            // NOT signal EOF here (it would trigger a corrupting re-open). Only give up if the pump
-            // has been fully dry (no segment for any track) long enough to be a genuine dead stall.
+            // not cached yet: pump's fetching or the server's pacing us. wait, don't signal EOF
+            // (that triggers a corrupting re-open). only bail if the pump's been fully dry long
+            // enough to be a real dead stall.
             if (pump.millisSinceLastSegment() > STALL_MS) {
                 Log.i(TAG, "end of SABR stream (stalled) itag=" + format.getItag()
                         + " at seq=" + nextSeq);

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -1,0 +1,254 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.content.Context;
+import android.media.MediaCodecInfo;
+import android.media.MediaCodecList;
+
+import androidx.annotation.NonNull;
+
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.localization.ContentCountry;
+import org.schabi.newpipe.extractor.localization.Localization;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrPoTokenProvider;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrSegmentRequest;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrClientProfile;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrFormat;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrInfo;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrSession;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Caches one shared {@link YoutubeSabrSession} per videoId so the audio and video
+ * {@link SabrDataSource}s drive the same session (a single SABR response carries both formats, so
+ * the session's segment cache serves both without doubling bandwidth).
+ *
+ * <p>v1: uses the best audio/video formats from the player response and a fixed en/US locale.</p>
+ */
+public final class SabrSessionStore {
+
+    private static final Map<String, Holder> SESSIONS = new ConcurrentHashMap<>();
+    // Keep only the few most-recent sessions so the map + per-video segment caches + pump threads
+    // don't accumulate forever as the user browses videos. Mutated only under the class lock.
+    private static final int MAX_SESSIONS = 3;
+    private static final java.util.Deque<String> ORDER = new java.util.ArrayDeque<>();
+    // Shared across videos so the PO-token cache (videoId-keyed, ~6h) is reused and a single
+    // WebView is held instead of one per video.
+    private static volatile WebViewPoTokenProvider sharedProvider;
+
+    private SabrSessionStore() {
+    }
+
+    @NonNull
+    private static WebViewPoTokenProvider provider(@NonNull final Context context) {
+        WebViewPoTokenProvider p = sharedProvider;
+        if (p == null) {
+            synchronized (SabrSessionStore.class) {
+                p = sharedProvider;
+                if (p == null) {
+                    p = new WebViewPoTokenProvider(context.getApplicationContext());
+                    sharedProvider = p;
+                }
+            }
+        }
+        return p;
+    }
+
+    /** Bundle of the session and its selected formats for a given video. */
+    public static final class Holder {
+        @NonNull public final String videoId;
+        @NonNull public final YoutubeSabrInfo info;
+        @NonNull public final YoutubeSabrSession session;
+        @NonNull public final YoutubeSabrFormat audioFormat;
+        @NonNull public final YoutubeSabrFormat videoFormat;
+
+        // Real playback position (ms); written by the player loop, read by the pump.
+        private volatile long playerTimeMs;
+        private volatile SabrStreamPump pump;
+
+        Holder(@NonNull final String videoId,
+               @NonNull final YoutubeSabrInfo info,
+               @NonNull final YoutubeSabrSession session,
+               @NonNull final YoutubeSabrFormat audioFormat,
+               @NonNull final YoutubeSabrFormat videoFormat) {
+            this.videoId = videoId;
+            this.info = info;
+            this.session = session;
+            this.audioFormat = audioFormat;
+            this.videoFormat = videoFormat;
+        }
+
+        public long getPlayerTimeMs() {
+            return playerTimeMs;
+        }
+
+        void setPlayerTimeMs(final long playerTimeMs) {
+            this.playerTimeMs = playerTimeMs;
+        }
+
+        /** Lazily create the single background pump that feeds both data sources for this video. */
+        synchronized SabrStreamPump getPump(@NonNull final Localization localization) {
+            if (pump == null) {
+                pump = new SabrStreamPump(session, this, localization);
+            }
+            return pump;
+        }
+
+        boolean isBeyondEnd(@NonNull final SabrSegmentRequest request) {
+            return session.isBeyondEnd(request);
+        }
+    }
+
+    // Report the real playback position; no-op when the video has no live SABR session.
+    public static void updatePlayerTime(@NonNull final String videoId, final long playerTimeMs) {
+        final Holder holder = SESSIONS.get(videoId);
+        if (holder != null && playerTimeMs >= 0) {
+            holder.setPlayerTimeMs(playerTimeMs);
+        }
+    }
+
+    @NonNull
+    public static Holder getOrCreate(@NonNull final Context context,
+                                     @NonNull final String videoId)
+            throws IOException, ExtractionException {
+        final Holder existing = SESSIONS.get(videoId);
+        if (existing != null) {
+            return existing;
+        }
+        synchronized (SabrSessionStore.class) {
+            final Holder racing = SESSIONS.get(videoId);
+            if (racing != null) {
+                return racing;
+            }
+            final Localization localization = new Localization("en", "US");
+            final ContentCountry contentCountry = new ContentCountry("US");
+            final YoutubeSabrInfo info = YoutubeSabrProbeFetch(videoId, localization, contentCountry);
+            final YoutubeSabrFormat audioFormat = info.findBestAudioFormat();
+            final YoutubeSabrFormat videoFormat = pickHardwareFriendlyVideo(info);
+            if (audioFormat == null || videoFormat == null) {
+                throw new IOException("SABR: could not select audio/video formats for " + videoId);
+            }
+            final SabrPoTokenProvider provider = provider(context);
+            final YoutubeSabrSession session =
+                    new YoutubeSabrSession(info, audioFormat, videoFormat, provider);
+            final Holder holder = new Holder(videoId, info, session, audioFormat, videoFormat);
+            SESSIONS.put(videoId, holder);
+            // LRU bound: evict the oldest sessions (their pumps are stopped, caches freed).
+            ORDER.remove(videoId);
+            ORDER.addLast(videoId);
+            while (ORDER.size() > MAX_SESSIONS) {
+                final String old = ORDER.pollFirst();
+                if (old != null && !old.equals(videoId)) {
+                    evict(old);
+                }
+            }
+            // Pre-warm the PO token off-thread so the ~45s WebView mint overlaps the initial probe
+            // and buffering instead of stalling the pump on its first protected response.
+            final Thread warm = new Thread(() -> {
+                try {
+                    provider.getPoToken(info, session.getStreamState());
+                } catch (final Exception ignored) {
+                    // Best-effort; the pump mints on demand if this fails.
+                }
+            }, "SabrTokenPrewarm");
+            warm.setDaemon(true);
+            warm.start();
+            return holder;
+        }
+    }
+
+    @NonNull
+    private static YoutubeSabrInfo YoutubeSabrProbeFetch(@NonNull final String videoId,
+                                                        @NonNull final Localization localization,
+                                                        @NonNull final ContentCountry contentCountry)
+            throws IOException, ExtractionException {
+        return org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrProbe.fetchSabrInfo(
+                videoId, YoutubeSabrClientProfile.WEB, localization, contentCountry);
+    }
+
+    /**
+     * Pick the highest-resolution video format the device can decode in HARDWARE. The decoder is
+     * chosen by ExoPlayer from the container bytes, so a codec the device only decodes in software
+     * (e.g. AV1 on most phones, or VP9 where there's no HW VP9) melts the CPU and overheats. So we
+     * allow AVC always (universally HW), VP9 only when a HW VP9 decoder exists, AV1 only when a HW
+     * AV1 decoder exists; otherwise fall back to the overall best (better some playback than none).
+     */
+    @NonNull
+    private static YoutubeSabrFormat pickHardwareFriendlyVideo(@NonNull final YoutubeSabrInfo info) {
+        final boolean hwVp9 = hasHardwareDecoder("video/x-vnd.on2.vp9");
+        final boolean hwAv1 = hasHardwareDecoder("video/av01");
+        YoutubeSabrFormat best = null;
+        for (final YoutubeSabrFormat f : info.getFormats()) {
+            if (!f.isVideo()) {
+                continue;
+            }
+            final String codec = codecFamily(f.getMimeType());
+            final boolean decodable = "avc".equals(codec)
+                    || ("vp9".equals(codec) && hwVp9)
+                    || ("av1".equals(codec) && hwAv1);
+            if (!decodable) {
+                continue;
+            }
+            if (best == null || f.getHeight() > best.getHeight()
+                    || (f.getHeight() == best.getHeight() && f.getBitrate() > best.getBitrate())) {
+                best = f;
+            }
+        }
+        return best != null ? best : info.findBestVideoFormat();
+    }
+
+    /** Normalise a SABR format mimeType ({@code codecs="..."}) to a codec family, or null. */
+    @NonNull
+    private static String codecFamily(final String mimeType) {
+        if (mimeType == null) {
+            return "";
+        }
+        if (mimeType.contains("avc1") || mimeType.contains("avc3")) {
+            return "avc";
+        }
+        if (mimeType.contains("vp9") || mimeType.contains("vp09")) {
+            return "vp9";
+        }
+        if (mimeType.contains("av01")) {
+            return "av1";
+        }
+        return "";
+    }
+
+    /** True if the device exposes a non-software (hardware) decoder for the given mime type. */
+    private static boolean hasHardwareDecoder(@NonNull final String mimeType) {
+        try {
+            for (final MediaCodecInfo codec
+                    : new MediaCodecList(MediaCodecList.ALL_CODECS).getCodecInfos()) {
+                if (codec.isEncoder()) {
+                    continue;
+                }
+                final String name = codec.getName().toLowerCase();
+                // Software decoders on Android are named c2.android.* / c2.google.* / omx.google.*.
+                if (name.startsWith("c2.android.") || name.startsWith("c2.google.")
+                        || name.startsWith("omx.google.")) {
+                    continue;
+                }
+                for (final String type : codec.getSupportedTypes()) {
+                    if (type.equalsIgnoreCase(mimeType)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (final Exception e) {
+            // If capability probing fails, be conservative (treat as no HW decoder).
+            return false;
+        }
+        return false;
+    }
+
+    /** Evict a cached session, stopping its pump so the thread + buffers are released. */
+    public static void evict(@NonNull final String videoId) {
+        final Holder holder = SESSIONS.remove(videoId);
+        if (holder != null && holder.pump != null) {
+            holder.pump.stop();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
@@ -18,8 +18,8 @@ import java.util.List;
  * Single consumer of a {@link YoutubeSabrSession}: one daemon thread pumps the server-driven SABR
  * stream and fills the session's (concurrent) segment cache ahead of the play head. The server
  * paces us with policy-only responses once we are far enough ahead. Both the audio and video
- * {@link SabrDataSource}s only read the cache, so they never contend on the session nor block each
- * other on a network round-trip — which is what made the on-demand approach stall and starve a track.
+ * {@link SabrDataSource}s only read the cache, so they never fight over the session or block each
+ * other on a network round-trip, which is exactly what starved a track in the old on-demand approach.
  */
 final class SabrStreamPump {
 
@@ -78,7 +78,7 @@ final class SabrStreamPump {
         }
     }
 
-    /** Milliseconds since the pump last received any segment — its global liveness signal. */
+    /** ms since the pump last grabbed a segment. basically "is this thing dead or what". */
     long millisSinceLastSegment() {
         return System.currentTimeMillis() - lastSegmentMs;
     }
@@ -94,6 +94,8 @@ final class SabrStreamPump {
     }
 
     private void loop() {
+        Log.i(TAG, "SABR-DIAG pump start: aFmt=" + holder.audioFormat.getItag()
+                + " vFmt=" + holder.videoFormat.getItag() + " video=" + holder.videoId);
         try {
             while (!stopped) {
                 if (System.currentTimeMillis() - lastReadMs > IDLE_STOP_MS || session.isComplete()) {
@@ -111,9 +113,10 @@ final class SabrStreamPump {
                     Thread.currentThread().interrupt();
                     break;
                 } catch (final IOException e) {
+                    Log.i(TAG, "SABR-DIAG transient IO, retry: " + e.getMessage());
                     sleepQuietly(ERROR_RETRY_MS);
                 } catch (final ExtractionException e) {
-                    Log.i(TAG, "SABR pump fatal: " + e.getMessage());
+                    Log.w(TAG, "SABR-DIAG pump FATAL (session evicted): " + e.getMessage(), e);
                     fatal = true;
                     // Drop the dead session so a re-open rebuilds a fresh one (new token, new state).
                     SabrSessionStore.evict(holder.videoId);

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
@@ -1,0 +1,137 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.localization.Localization;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrMediaSegment;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrSegmentRequest;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrSession;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Single consumer of a {@link YoutubeSabrSession}: one daemon thread pumps the server-driven SABR
+ * stream and fills the session's (concurrent) segment cache ahead of the play head. The server
+ * paces us with policy-only responses once we are far enough ahead. Both the audio and video
+ * {@link SabrDataSource}s only read the cache, so they never contend on the session nor block each
+ * other on a network round-trip — which is what made the on-demand approach stall and starve a track.
+ */
+final class SabrStreamPump {
+
+    private static final String TAG = "SabrStreamPump";
+    private static final long IDLE_POLL_MS = 400;     // server paced us / nothing new this round
+    private static final long ERROR_RETRY_MS = 1000;  // transient network error
+    private static final long IDLE_STOP_MS = 15_000;  // no reads for this long -> playback is gone
+
+    private final YoutubeSabrSession session;
+    private final SabrSessionStore.Holder holder;
+    private final Localization localization;
+
+    private volatile boolean started;
+    private volatile boolean stopped;
+    private volatile boolean fatal;
+    private volatile long lastReadMs;
+    private volatile long lastSegmentMs;
+    private Thread thread;
+
+    SabrStreamPump(@NonNull final YoutubeSabrSession session,
+                   @NonNull final SabrSessionStore.Holder holder,
+                   @NonNull final Localization localization) {
+        this.session = session;
+        this.holder = holder;
+        this.localization = localization;
+    }
+
+    /** Start (or restart, if it idled out) the pump thread, and mark the session as actively read. */
+    void ensureStarted() {
+        lastReadMs = System.currentTimeMillis();
+        if (fatal || (started && !stopped)) {
+            return;
+        }
+        synchronized (this) {
+            if (fatal || (started && !stopped)) {
+                return;
+            }
+            stopped = false;
+            started = true;
+            lastSegmentMs = System.currentTimeMillis();
+            thread = new Thread(this::loop, "SabrStreamPump");
+            thread.setDaemon(true);
+            thread.start();
+        }
+    }
+
+    /** Stop the pump thread and release it (called on eviction / playback teardown). */
+    void stop() {
+        synchronized (this) {
+            stopped = true;
+            // Don't self-interrupt: stop() is also reached from the pump thread itself via
+            // evict-on-fatal, and setting our own interrupt flag could break a later blocking call.
+            if (thread != null && thread != Thread.currentThread()) {
+                thread.interrupt();
+            }
+        }
+    }
+
+    /** Milliseconds since the pump last received any segment — its global liveness signal. */
+    long millisSinceLastSegment() {
+        return System.currentTimeMillis() - lastSegmentMs;
+    }
+
+    @Nullable
+    SabrMediaSegment getCached(@NonNull final SabrSegmentRequest request) {
+        lastReadMs = System.currentTimeMillis();
+        return session.getCachedSegment(request);
+    }
+
+    boolean isFatal() {
+        return fatal;
+    }
+
+    private void loop() {
+        try {
+            while (!stopped) {
+                if (System.currentTimeMillis() - lastReadMs > IDLE_STOP_MS || session.isComplete()) {
+                    break;
+                }
+                try {
+                    session.getStreamState().setPlayerTimeMs(Math.max(0, holder.getPlayerTimeMs()));
+                    final List<SabrMediaSegment> segments = session.pumpOnce(localization);
+                    if (segments.isEmpty()) {
+                        Thread.sleep(IDLE_POLL_MS);
+                    } else {
+                        lastSegmentMs = System.currentTimeMillis();
+                    }
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (final IOException e) {
+                    sleepQuietly(ERROR_RETRY_MS);
+                } catch (final ExtractionException e) {
+                    Log.i(TAG, "SABR pump fatal: " + e.getMessage());
+                    fatal = true;
+                    // Drop the dead session so a re-open rebuilds a fresh one (new token, new state).
+                    SabrSessionStore.evict(holder.videoId);
+                    break;
+                }
+            }
+        } finally {
+            synchronized (this) {
+                stopped = true;
+            }
+        }
+    }
+
+    private static void sleepQuietly(final long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
@@ -27,6 +27,9 @@ final class SabrStreamPump {
     private static final long IDLE_POLL_MS = 400;     // server paced us / nothing new this round
     private static final long ERROR_RETRY_MS = 1000;  // transient network error
     private static final long IDLE_STOP_MS = 15_000;  // no reads for this long -> playback is gone
+    // how far ahead of the play head we let ourselves buffer. enough to not stutter, not so much
+    // that we hoard the whole video and start evicting segments the player hasn't even reached.
+    private static final long READAHEAD_CUSHION_MS = 30_000;
 
     private final YoutubeSabrSession session;
     private final SabrSessionStore.Holder holder;
@@ -94,15 +97,26 @@ final class SabrStreamPump {
     }
 
     private void loop() {
-        Log.i(TAG, "SABR-DIAG pump start: aFmt=" + holder.audioFormat.getItag()
-                + " vFmt=" + holder.videoFormat.getItag() + " video=" + holder.videoId);
         try {
             while (!stopped) {
                 if (System.currentTimeMillis() - lastReadMs > IDLE_STOP_MS || session.isComplete()) {
                     break;
                 }
                 try {
-                    session.getStreamState().setPlayerTimeMs(Math.max(0, holder.getPlayerTimeMs()));
+                    final long realMs = Math.max(0, holder.getPlayerTimeMs());
+                    // follow the SLOWER track (min). if one lags we keep feeding it instead of
+                    // sitting on our hands while it starves. and we stop a cushion ahead so we don't
+                    // buffer the whole video and evict segments nobody's watched yet.
+                    final long edgeMs = session.getStreamState().getMinBufferedEndMs();
+                    if (edgeMs - realMs > READAHEAD_CUSHION_MS) {
+                        Thread.sleep(IDLE_POLL_MS);
+                        continue;
+                    }
+                    // report the buffered edge as our position, not 0. say 0 and the server figures
+                    // we're full and stops feeding. say the edge and the segments keep coming.
+                    final long reportMs = Math.min(Math.max(realMs, edgeMs),
+                            realMs + READAHEAD_CUSHION_MS);
+                    session.getStreamState().setPlayerTimeMs(reportMs);
                     final List<SabrMediaSegment> segments = session.pumpOnce(localization);
                     if (segments.isEmpty()) {
                         Thread.sleep(IDLE_POLL_MS);
@@ -113,10 +127,9 @@ final class SabrStreamPump {
                     Thread.currentThread().interrupt();
                     break;
                 } catch (final IOException e) {
-                    Log.i(TAG, "SABR-DIAG transient IO, retry: " + e.getMessage());
                     sleepQuietly(ERROR_RETRY_MS);
                 } catch (final ExtractionException e) {
-                    Log.w(TAG, "SABR-DIAG pump FATAL (session evicted): " + e.getMessage(), e);
+                    Log.i(TAG, "SABR pump fatal: " + e.getMessage());
                     fatal = true;
                     // Drop the dead session so a re-open rebuilds a fresh one (new token, new state).
                     SabrSessionStore.evict(holder.videoId);

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
@@ -1,0 +1,281 @@
+package org.schabi.newpipe.player.datasource;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.annotation.Nullable;
+
+import org.json.JSONObject;
+import org.schabi.newpipe.extractor.services.youtube.sabr.SabrPoTokenProvider;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrInfo;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrStreamState;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Generates YouTube SABR PO tokens by running the official BotGuard challenge inside a headless
+ * WebView (the legitimate attestation runtime), then handing the minted, videoId-bound token to the
+ * extractor's SABR session via {@link SabrPoTokenProvider}.
+ *
+ * <p>Validated end to end (emulator + Pixel 8 / GrapheneOS Vanadium): the WebView produces a token
+ * GenerateIT accepts and that flips SABR protection status 2 -> 1.</p>
+ *
+ * <p>The provider blocks the calling (loading) thread on a latch while the WebView, driven on the
+ * main thread, runs the pipeline. Tokens are cached per videoId (~6h, well under the measured ~7-8h
+ * lifetime).</p>
+ */
+public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
+
+    private static final String TAG = "WebViewPoToken";
+    private static final String ASSET = "sabr_potoken_poc.js";
+    private static final String DESKTOP_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
+    private static final long TOKEN_TTL_MS = 6L * 60L * 60L * 1000L; // 6 hours
+    private static final long PIPELINE_TIMEOUT_MS = 45_000L;
+    private static final int READY_RETRIES = 20;
+    private static final long READY_POLL_MS = 250L;
+
+    private static final class CachedToken {
+        private final byte[] token;
+        private final long mintedAtMs;
+
+        CachedToken(final byte[] token, final long mintedAtMs) {
+            this.token = token;
+            this.mintedAtMs = mintedAtMs;
+        }
+    }
+
+    private final Context appContext;
+    private final Handler mainHandler;
+    private final Map<String, CachedToken> cache = new ConcurrentHashMap<>();
+    // Per-videoId lock so concurrent callers (e.g. a pre-warm and the pump) don't both run the
+    // expensive ~45s WebView mint for the same video — the second waits and gets the cached result.
+    private final Map<String, Object> mintLocks = new ConcurrentHashMap<>();
+
+    public WebViewPoTokenProvider(final Context context) {
+        this.appContext = context.getApplicationContext();
+        this.mainHandler = new Handler(Looper.getMainLooper());
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPoToken(final YoutubeSabrInfo info, final YoutubeSabrStreamState streamState) {
+        return getPoToken(info, streamState, false);
+    }
+
+    @Nullable
+    @Override
+    public byte[] getPoToken(final YoutubeSabrInfo info, final YoutubeSabrStreamState streamState,
+                             final boolean forceRefresh) {
+        final String videoId = info.getVideoId();
+        if (forceRefresh) {
+            // Server rejected the cached token (expired): drop it and mint a fresh one.
+            cache.remove(videoId);
+        }
+        synchronized (mintLocks.computeIfAbsent(videoId, k -> new Object())) {
+            final long now = System.currentTimeMillis();
+            final CachedToken cached = cache.get(videoId);
+            if (cached != null && now - cached.mintedAtMs < TOKEN_TTL_MS) {
+                return cached.token;
+            }
+            final String tokenB64 = mintBlocking(videoId);
+            if (tokenB64 == null || tokenB64.isEmpty()) {
+                return null;
+            }
+            final byte[] token;
+            try {
+                token = Base64.getUrlDecoder().decode(tokenB64);
+            } catch (final IllegalArgumentException e) {
+                Log.e(TAG, "could not decode PO token", e);
+                return null;
+            }
+            cache.put(videoId, new CachedToken(token, now));
+            return token;
+        }
+    }
+
+    @Nullable
+    private String mintBlocking(final String videoId) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<String> tokenRef = new AtomicReference<>();
+        final AtomicReference<WebView> webViewRef = new AtomicReference<>();
+
+        mainHandler.post(() -> {
+            try {
+                webViewRef.set(createWebView(videoId, tokenRef, latch));
+            } catch (final Exception e) {
+                Log.e(TAG, "failed to start WebView pipeline", e);
+                latch.countDown();
+            }
+        });
+
+        try {
+            if (!latch.await(PIPELINE_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                Log.w(TAG, "PO token pipeline timed out for " + videoId);
+            }
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            mainHandler.post(() -> destroyWebView(webViewRef.getAndSet(null)));
+        }
+        return tokenRef.get();
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private WebView createWebView(final String videoId,
+                                  final AtomicReference<String> tokenRef,
+                                  final CountDownLatch latch) {
+        final WebView webView = new WebView(appContext);
+        final WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setUserAgentString(DESKTOP_UA);
+        webView.addJavascriptInterface(new Bridge(tokenRef, latch), "SabrPocBridge");
+        webView.setWebViewClient(new WebViewClient() {
+            private boolean injected = false;
+
+            @Override
+            public WebResourceResponse shouldInterceptRequest(final WebView view,
+                                                              final WebResourceRequest request) {
+                final String url = request.getUrl().toString();
+                if (url.contains("/js/th/")) {
+                    return fetchWithCors(url);
+                }
+                return super.shouldInterceptRequest(view, request);
+            }
+
+            @Override
+            public void onPageFinished(final WebView view, final String url) {
+                super.onPageFinished(view, url);
+                if (injected || url == null || !url.contains("youtube.com")) {
+                    return;
+                }
+                injected = true;
+                waitForReadyThenInject(view, videoId, 0);
+            }
+        });
+        webView.loadUrl("https://www.youtube.com/");
+        return webView;
+    }
+
+    private void waitForReadyThenInject(final WebView view, final String videoId, final int attempt) {
+        view.evaluateJavascript("document.readyState", value -> {
+            final boolean complete = value != null && value.contains("complete");
+            if (complete || attempt >= READY_RETRIES) {
+                view.evaluateJavascript(
+                        "window.__SABR_POC_VIDEO_ID=" + jsString(videoId) + ";", null);
+                view.evaluateJavascript(loadPipelineScript(), null);
+            } else {
+                mainHandler.postDelayed(
+                        () -> waitForReadyThenInject(view, videoId, attempt + 1), READY_POLL_MS);
+            }
+        });
+    }
+
+    private static void destroyWebView(@Nullable final WebView webView) {
+        if (webView == null) {
+            return;
+        }
+        try {
+            webView.stopLoading();
+            webView.loadUrl("about:blank");
+            webView.removeAllViews();
+            webView.destroy();
+        } catch (final Exception ignored) {
+            // best effort
+        }
+    }
+
+    private static String jsString(final String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    private String loadPipelineScript() {
+        try (InputStream in = appContext.getAssets().open(ASSET);
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            final byte[] chunk = new byte[8192];
+            int read;
+            while ((read = in.read(chunk)) != -1) {
+                out.write(chunk, 0, read);
+            }
+            return out.toString("UTF-8");
+        } catch (final Exception e) {
+            Log.e(TAG, "could not read pipeline asset", e);
+            return "";
+        }
+    }
+
+    @Nullable
+    private static WebResourceResponse fetchWithCors(final String url) {
+        try {
+            final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestProperty("User-Agent", DESKTOP_UA);
+            connection.setConnectTimeout(15000);
+            connection.setReadTimeout(15000);
+            final int code = connection.getResponseCode();
+            final InputStream body = code >= 400
+                    ? connection.getErrorStream() : connection.getInputStream();
+            final String contentType = connection.getContentType();
+            String mime = "application/javascript";
+            if (contentType != null) {
+                final int sep = contentType.indexOf(';');
+                mime = sep > 0 ? contentType.substring(0, sep).trim() : contentType.trim();
+            }
+            final Map<String, String> headers = new HashMap<>();
+            headers.put("Access-Control-Allow-Origin", "*");
+            final WebResourceResponse response = new WebResourceResponse(mime, "UTF-8", body);
+            response.setStatusCodeAndReasonPhrase(code, code >= 400 ? "ERROR" : "OK");
+            response.setResponseHeaders(headers);
+            return response;
+        } catch (final Exception e) {
+            Log.e(TAG, "interpreter native fetch failed", e);
+            return null;
+        }
+    }
+
+    private static final class Bridge {
+        private final AtomicReference<String> tokenRef;
+        private final CountDownLatch latch;
+
+        Bridge(final AtomicReference<String> tokenRef, final CountDownLatch latch) {
+            this.tokenRef = tokenRef;
+            this.latch = latch;
+        }
+
+        @JavascriptInterface
+        public void onResult(final String json) {
+            try {
+                final JSONObject obj = new JSONObject(json);
+                if (obj.optBoolean("ok", false)) {
+                    tokenRef.set(obj.optString("poToken", null));
+                } else {
+                    Log.w(TAG, "PO token pipeline failed: " + obj.optString("error", "unknown"));
+                }
+            } catch (final Exception e) {
+                Log.e(TAG, "could not parse pipeline result", e);
+            } finally {
+                latch.countDown();
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
@@ -68,8 +68,8 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
     private final Context appContext;
     private final Handler mainHandler;
     private final Map<String, CachedToken> cache = new ConcurrentHashMap<>();
-    // Per-videoId lock so concurrent callers (e.g. a pre-warm and the pump) don't both run the
-    // expensive ~45s WebView mint for the same video — the second waits and gets the cached result.
+    // one lock per videoId so two callers (pre-warm + pump) don't both fire the ~45s WebView mint
+    // for the same video. second one just waits and takes the cached token.
     private final Map<String, Object> mintLocks = new ConcurrentHashMap<>();
 
     public WebViewPoTokenProvider(final Context context) {

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -47,6 +47,12 @@ import org.schabi.newpipe.player.helper.PlayerDataSource;
 import org.schabi.newpipe.player.mediaitem.MediaItemTag;
 import org.schabi.newpipe.player.mediaitem.StreamInfoTag;
 import org.schabi.newpipe.util.StreamTypeUtil;
+import org.schabi.newpipe.App;
+import org.schabi.newpipe.extractor.exceptions.ExtractionException;
+import org.schabi.newpipe.extractor.localization.Localization;
+import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrFormat;
+import org.schabi.newpipe.player.datasource.SabrDataSource;
+import org.schabi.newpipe.player.datasource.SabrSessionStore;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -437,10 +443,37 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                                 .setUri(Uri.parse(stream.getContent()))
                                 .setCustomCacheKey(cacheKey)
                                 .build());
+            case SABR:
+                return buildSabrMediaSource(stream, streamInfo, cacheKey, metadata);
             default:
                 throw new IOException("Unsupported delivery method for YouTube contents: "
                         + deliveryMethod);
         }
+    }
+
+    @NonNull
+    private static MediaSource buildSabrMediaSource(@NonNull final Stream stream,
+                                                    @NonNull final StreamInfo streamInfo,
+                                                    @NonNull final String cacheKey,
+                                                    @NonNull final MediaItemTag metadata)
+            throws IOException {
+        final String videoId = streamInfo.getId();
+        final SabrSessionStore.Holder holder;
+        try {
+            holder = SabrSessionStore.getOrCreate(App.getApp(), videoId);
+        } catch (final ExtractionException e) {
+            throw new IOException("Could not start SABR session for " + videoId, e);
+        }
+        final YoutubeSabrFormat format = (stream instanceof AudioStream)
+                ? holder.audioFormat : holder.videoFormat;
+        final SabrDataSource.Factory factory = new SabrDataSource.Factory(
+                holder, format, new Localization("en", "US"));
+        return new ProgressiveMediaSource.Factory(factory).createMediaSource(
+                new MediaItem.Builder()
+                        .setTag(metadata)
+                        .setUri(Uri.parse("sabr://" + videoId + "/" + format.getItag()))
+                        .setCustomCacheKey(cacheKey)
+                        .build());
     }
 
     @NonNull

--- a/app/src/main/java/org/schabi/newpipe/views/SabrPoTokenPocActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/views/SabrPoTokenPocActivity.java
@@ -1,0 +1,164 @@
+package org.schabi.newpipe.views;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.webkit.JavascriptInterface;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.schabi.newpipe.R;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Local POC activity: runs the SABR PO token pipeline inside a WebView on www.youtube.com and
+ * reports the result. INTERNAL / LOCAL ONLY, not wired into any user-facing flow.
+ *
+ * <p>Launch on a debug build:</p>
+ * <pre>
+ *   adb shell am start -n &lt;applicationId&gt;/org.schabi.newpipe.views.SabrPoTokenPocActivity \
+ *       -e videoId aqz-KE-bpKQ
+ * </pre>
+ *
+ * <p>The full result (including the session-bound token) is written to the app-private files dir as
+ * {@code sabr_poc_result.json}; a token-free summary is logged under the {@code SABR_POC} tag.</p>
+ */
+public class SabrPoTokenPocActivity extends AppCompatActivity {
+
+    private static final String TAG = "SABR_POC";
+    private static final String DEFAULT_VIDEO_ID = "aqz-KE-bpKQ";
+    private static final String DESKTOP_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            + "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36";
+
+    private WebView webView;
+    private boolean injected = false;
+    private String videoId = DEFAULT_VIDEO_ID;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.login_webview);
+
+        final String extra = getIntent() != null ? getIntent().getStringExtra("videoId") : null;
+        if (extra != null && !extra.isEmpty()) {
+            videoId = extra;
+        }
+
+        webView = findViewById(R.id.login_webview);
+        final WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        // Desktop UA so YouTube serves www.youtube.com (consistent with the research mint context).
+        settings.setUserAgentString(DESKTOP_UA);
+        webView.addJavascriptInterface(new PocBridge(), "SabrPocBridge");
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public WebResourceResponse shouldInterceptRequest(final WebView view,
+                                                              final WebResourceRequest request) {
+                final String url = request.getUrl().toString();
+                // The BotGuard interpreter is served cross-origin (www.google.com/js/th/...), which
+                // a page-context fetch cannot read (no CORS header). Re-fetch it natively (no CORS)
+                // and hand it back with a permissive ACAO header so the pipeline's fetch succeeds.
+                if (url.contains("/js/th/")) {
+                    return fetchWithCors(url);
+                }
+                return super.shouldInterceptRequest(view, request);
+            }
+
+            @Override
+            public void onPageFinished(final WebView view, final String url) {
+                super.onPageFinished(view, url);
+                if (injected || url == null || !url.contains("youtube.com")) {
+                    return;
+                }
+                injected = true;
+                Log.i(TAG, "page finished, injecting SABR PO token pipeline for videoId=" + videoId);
+                view.evaluateJavascript(
+                        "window.__SABR_POC_VIDEO_ID=" + jsString(videoId) + ";", null);
+                view.evaluateJavascript(loadPipelineScript(), null);
+            }
+        });
+        webView.loadUrl("https://www.youtube.com/");
+    }
+
+    private static String jsString(final String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    private String loadPipelineScript() {
+        try (InputStream in = getAssets().open("sabr_potoken_poc.js");
+             BufferedReader reader = new BufferedReader(
+                     new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            final StringBuilder builder = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line).append('\n');
+            }
+            return builder.toString();
+        } catch (final Exception e) {
+            Log.e(TAG, "could not read pipeline asset", e);
+            return "";
+        }
+    }
+
+    private static WebResourceResponse fetchWithCors(final String url) {
+        try {
+            final HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+            connection.setRequestProperty("User-Agent", DESKTOP_UA);
+            connection.setConnectTimeout(15000);
+            connection.setReadTimeout(15000);
+            final int code = connection.getResponseCode();
+            final InputStream body = code >= 400
+                    ? connection.getErrorStream() : connection.getInputStream();
+            final String contentType = connection.getContentType();
+            String mime = "application/javascript";
+            if (contentType != null) {
+                final int sep = contentType.indexOf(';');
+                mime = sep > 0 ? contentType.substring(0, sep).trim() : contentType.trim();
+            }
+            final Map<String, String> headers = new HashMap<>();
+            headers.put("Access-Control-Allow-Origin", "*");
+            final WebResourceResponse response = new WebResourceResponse(mime, "UTF-8", body);
+            response.setStatusCodeAndReasonPhrase(code, code >= 400 ? "ERROR" : "OK");
+            response.setResponseHeaders(headers);
+            return response;
+        } catch (final Exception e) {
+            Log.e(TAG, "interpreter native fetch failed for " + url, e);
+            return null;
+        }
+    }
+
+    private final class PocBridge {
+        @JavascriptInterface
+        public void onResult(final String json) {
+            try {
+                final File out = new File(getFilesDir(), "sabr_poc_result.json");
+                try (FileOutputStream fos = new FileOutputStream(out)) {
+                    fos.write(json.getBytes(StandardCharsets.UTF_8));
+                }
+                Log.i(TAG, "result written to " + out.getAbsolutePath());
+            } catch (final Exception e) {
+                Log.e(TAG, "could not persist result", e);
+            }
+            Log.i(TAG, "result: " + redactToken(json));
+        }
+    }
+
+    private static String redactToken(final String json) {
+        return json.replaceAll("\"poToken\":\"[^\"]*\"", "\"poToken\":\"<redacted>\"");
+    }
+}


### PR DESCRIPTION
PoC for the client side of SABR, paired with InfinityLoop1308/PipePipeExtractor#67. Tracking: #42.

**Docs** (how SABR works end to end): https://priveetee.github.io/Docs-PipePipe/developer-guide/introduction

Related:
- InfinityLoop1308/PipePipeExtractor#67 (extractor side)
- InfinityLoop1308/PipePipe#2330 ([YouTube] Content Not Yet Supported (SABR) after 5.1.0)
- TeamNewPipe/NewPipe#12248 ([YouTube] Coordinating efforts on SABR implementation)

## Summary
Adds a custom ExoPlayer source that plays SABR streams: a single pump thread drives the extractor's SABR session and fills a shared buffer, while the audio and video readers just read from it (so neither track starves the other on a network round-trip). The PO token is minted in a headless WebView (BotGuard), shared and pre-warmed, cached per videoId (~6h).

## Changes
- `SabrDataSource`: exposes one SABR format (audio or video) as a continuous byte stream from the session cache.
- `SabrStreamPump`: single daemon that pumps the server-driven SABR stream and fills the cache ahead of the play head.
- `SabrSessionStore`: one shared session per videoId, LRU-bounded, format selection by hardware decode.
- `WebViewPoTokenProvider`: headless WebView BotGuard runtime, token cached per videoId.
- Wires SABR into the player resolver behind the new delivery method.
- `SABR-DIAG` playback-path logging behind a flag.

## Why
So the extractor SABR work (#67) has a runnable end-to-end counterpart, and protected videos the old paths can't play actually play.

## Validation
- `./gradlew :app:assembleDebug`
- Installed debug APK on Pixel 8 (GrapheneOS / Vanadium WebView).
- SABR video plays end to end: token flips protection back to playable, hardware VP9/H264, no OOM, no overheating.
- Verified on-device via adb logs that token mint, segment download and the H264 1080p decoder all work.

## Notes
- PoC / reference, not merge-ready. Sustained playback still stalls: traced on-device to an asymmetric audio/video track stall in the player wiring (`MergingMediaSource` / `LoadControl`), where ExoPlayer stops pulling the video track after the first segment while audio races ahead. Details in #42. Not the protocol, protection, or decoding.
- Seek and quality selection aren't wired yet.
- Built on ExoPlayer 2.18.7 for now. If you're cool with it, I'd love to port this over to media3 progressively. It's gonna be a fair bit of work, but I'm more than happy to go on that journey with u.
