### PR TITLE
fix: the segments of the seekbar are now updated when changing video

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -3559,6 +3559,8 @@ public final class Player implements
                 closeItemsList();
             }
         }
+
+        onMarkSeekbarRequested(info);
     }
 
     private void updateMetadataWith(@NonNull final StreamInfo streamInfo) {


### PR DESCRIPTION
the segments of the seekbar are only updated in 3 cases:

1. when a new player is created
2. when creating a new segment
3. when deleting a new segment

but the segments displayed on the seek bar should be updated whenever a new video is played.
since selecting a new video to play changes the current metadata, and the metadata are needed to update the segments of the seekbar I think this change is a good way to solve this bug

I tested it on a google pixel 8a and didn't notice any new bug

this change fixes #https://github.com/InfinityLoop1308/PipePipe/issues/2397