### PR TITLE
fix(ui): edge-to-edge bottom-tab overlap + back button closing the app (targetSdk 37)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         android:logo="@mipmap/ic_launcher"
         android:theme="@style/OpeningTheme"
         android:resizeableActivity="true"
+        android:enableOnBackInvokedCallback="false"
         tools:ignore="AllowBackup">
         <activity
                 android:name=".MainActivity"

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -24,6 +24,8 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapterMenuWorkaround;
@@ -104,6 +106,17 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         binding.mainTabLayout.addOnTabSelectedListener(this);
         binding.mainTabLayout.setTabRippleColor(binding.mainTabLayout.getTabRippleColor()
                 .withAlpha(32));
+
+        // Edge-to-edge (targetSdk 35+): when the tab strip is moved to the bottom it sits behind the
+        // system navigation bar (tabs unclickable). Pad it by the nav-bar inset; the pager is laid
+        // out relative to the tab strip so it follows automatically. requestApplyInsets() in
+        // updateTabLayoutPosition() re-runs this when the user toggles the position.
+        ViewCompat.setOnApplyWindowInsetsListener(binding.mainTabLayout, (v, insets) -> {
+            final int navBottom = mainTabsPositionBottom
+                    ? insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom : 0;
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), navBottom);
+            return insets;
+        });
 
         setupTabs();
         updateTabLayoutPosition();
@@ -235,6 +248,9 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         tabLayout.setTabRippleColor(ColorStateList.valueOf(iconColor).withAlpha(32));
         tabLayout.setTabIconTint(ColorStateList.valueOf(iconColor));
         tabLayout.setSelectedTabIndicatorColor(iconColor);
+
+        // Re-apply the nav-bar inset padding for the new position (added at bottom, cleared at top).
+        ViewCompat.requestApplyInsets(tabLayout);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -724,6 +724,21 @@ public final class VideoDetailFragment
         pageAdapter = new TabAdapter(getChildFragmentManager());
         binding.viewPager.setAdapter(pageAdapter);
         binding.tabLayout.setupWithViewPager(binding.viewPager);
+        // Edge-to-edge (targetSdk 35+): the bottom tab strip is laid out gravity=bottom, so without
+        // insets it sits behind the system navigation bar (tabs unclickable) and the pager's last
+        // item runs under it. Pad the tab strip by the nav-bar inset and grow the pager's bottom
+        // padding (its XML 48dp tab clearance) by the same amount so content clears both.
+        final int viewPagerBottomBase = binding.viewPager.getPaddingBottom();
+        ViewCompat.setOnApplyWindowInsetsListener(binding.tabLayout, (v, insets) -> {
+            final int navBottom = insets.getInsets(
+                    WindowInsetsCompat.Type.navigationBars()).bottom;
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), navBottom);
+            binding.viewPager.setPadding(binding.viewPager.getPaddingLeft(),
+                    binding.viewPager.getPaddingTop(), binding.viewPager.getPaddingRight(),
+                    viewPagerBottomBase + navBottom);
+            return insets;
+        });
+        ViewCompat.requestApplyInsets(binding.tabLayout);
         updateStickyPlayerMode();
 
         binding.detailThumbnailRootLayout.requestFocus();

--- a/app/src/main/res/layout/fragment_video_detail.xml
+++ b/app/src/main/res/layout/fragment_video_detail.xml
@@ -626,6 +626,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="bottom|center"
+            android:background="?attr/windowBackground"
             app:tabIndicatorGravity="top"
             app:tabIconTint="?attr/colorAccent"
             app:tabBackground="?attr/windowBackground"


### PR DESCRIPTION
hey! this fixes both bugs from the 5.2.0-beta report in
[#2486 — Layout overlap issue, bottom UI](https://github.com/InfinityLoop1308/PipePipe/issues/2486)
(the bottom UI overlapping the nav bar, and the back button closing the app). both turned
out to be fallout from the targetSdk 37 bump, and your hunches in the thread were spot on :)

## what was happening
- the bottom tab strips (video detail comments/related/description/sponsorblock, and the
  main tabs when they're at the bottom) were drawing under the 3-button nav bar. targetSdk
  >=35 forces edge-to-edge, so anything anchored to the bottom that doesn't consume the
  nav-bar inset ends up behind it.
- the back button just closed the app: on android 16 back goes through OnBackInvokedCallback,
  and since we're on old androidx with nothing registered, the activity finished outright and
  our whole onBackPressed/BackPressable chain got skipped.

## what i changed
- VideoDetailFragment / MainFragment: pad the tab strips by the nav-bar inset (and bump the
  pager's bottom padding to match). adapts on its own to gesture nav.
- AndroidManifest: enableOnBackInvokedCallback="false" so back keeps going to the legacy
  onBackPressed like before.

just +32 lines across 3 files, nothing touched outside these paths.

## how i tested it
emulator, Pixel 8 AVD, android 16 (API 36), edge-to-edge on:
- tabs: before they sat under the nav bar, after they're above it (3-button); gesture nav
  unaffected; checked main-tabs-bottom and landscape too
- back: confirmed via logcat that onBackPressed fires again; tested home, search->home,
  detail collapse, fullscreen exit, and double-back still exits the app

heads up: only on the emulator for now, i'll try it on my actual phone once i'm back home,
but i'd bet it's the same result :)

Fixes [InfinityLoop1308/PipePipe#2486](https://github.com/InfinityLoop1308/PipePipe/issues/2486)
