### PR TITLE
fix(ui): keep the mini player above the navigation bar in edge-to-edge

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/MainActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/MainActivity.java
@@ -154,6 +154,9 @@ public class MainActivity extends AppCompatActivity {
 
         WindowInsetsHelper.applyStatusBarInsets(this, toolbarLayoutBinding.toolbar,
                 mainBinding.fragmentHolder);
+        // Edge-to-edge (targetSdk 35+): keep the main content (feed/search/channel/playlist lists,
+        // and the bottom tab strip) above the system navigation bar.
+        WindowInsetsHelper.applyNavigationBarInsets(mainBinding.fragmentHolder);
 
         if (getSupportFragmentManager().getBackStackEntryCount() == 0) {
             initFragments();

--- a/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/AboutActivity.kt
@@ -79,6 +79,8 @@ class AboutActivity : AppCompatActivity() {
                 aboutAppVersion.text = BuildConfig.VERSION_NAME
                 aboutGithubLink.openLink(R.string.github_url)
                 aboutDonationLink.openLink(R.string.donation_url)
+                // Edge-to-edge (targetSdk 35+): keep the bottom of the page above the nav bar.
+                WindowInsetsHelper.applyNavigationBarInsets(root)
                 return root
             }
         }

--- a/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
+++ b/app/src/main/java/org/schabi/newpipe/about/LicenseFragment.kt
@@ -11,6 +11,7 @@ import org.schabi.newpipe.R
 import org.schabi.newpipe.about.LicenseFragmentHelper.showLicense
 import org.schabi.newpipe.databinding.FragmentLicensesBinding
 import org.schabi.newpipe.databinding.ItemSoftwareComponentBinding
+import org.schabi.newpipe.util.WindowInsetsHelper
 
 /**
  * Fragment containing the software licenses.
@@ -67,6 +68,8 @@ class LicenseFragment : Fragment() {
             registerForContextMenu(root)
         }
         activeLicense?.let { compositeDisposable.add(showLicense(activity, it)) }
+        // Edge-to-edge (targetSdk 35+): keep the bottom of the licenses list above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(binding.root)
         return binding.root
     }
 

--- a/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadActivity.java
@@ -47,6 +47,8 @@ public class DownloadActivity extends AppCompatActivity {
         setSupportActionBar(downloaderBinding.toolbarLayout.toolbar);
 
         WindowInsetsHelper.applyStatusBarInsets(this, downloaderBinding.toolbarLayout.toolbar);
+        // Edge-to-edge (targetSdk 35+): keep the bottom of the downloads list above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(downloaderBinding.frame);
 
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ErrorActivity.java
@@ -108,6 +108,8 @@ public class ErrorActivity extends AppCompatActivity {
         WindowInsetsHelper.applyStatusBarInsets(this,
                 activityErrorBinding.toolbarLayout.toolbar,
                 activityErrorBinding.scrollView);
+        // Edge-to-edge (targetSdk 35+): keep the bottom of a long error report above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(activityErrorBinding.scrollView);
 
         final ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {

--- a/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/error/ReCaptchaActivity.java
@@ -81,6 +81,8 @@ public class ReCaptchaActivity extends AppCompatActivity {
 
         WindowInsetsHelper.applyStatusBarInsets(this, recaptchaBinding.toolbar,
                 recaptchaBinding.reCaptchaWebView);
+        // Edge-to-edge (targetSdk 35+): keep the captcha web view content above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(recaptchaBinding.reCaptchaWebView);
 
         final String url = sanitizeRecaptchaUrl(getIntent().getStringExtra(RECAPTCHA_URL_EXTRA));
         // set return to Cancel by default

--- a/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/MainFragment.java
@@ -24,8 +24,6 @@ import android.widget.RelativeLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
-import androidx.core.view.ViewCompat;
-import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapterMenuWorkaround;
@@ -106,17 +104,6 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         binding.mainTabLayout.addOnTabSelectedListener(this);
         binding.mainTabLayout.setTabRippleColor(binding.mainTabLayout.getTabRippleColor()
                 .withAlpha(32));
-
-        // Edge-to-edge (targetSdk 35+): when the tab strip is moved to the bottom it sits behind the
-        // system navigation bar (tabs unclickable). Pad it by the nav-bar inset; the pager is laid
-        // out relative to the tab strip so it follows automatically. requestApplyInsets() in
-        // updateTabLayoutPosition() re-runs this when the user toggles the position.
-        ViewCompat.setOnApplyWindowInsetsListener(binding.mainTabLayout, (v, insets) -> {
-            final int navBottom = mainTabsPositionBottom
-                    ? insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom : 0;
-            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), navBottom);
-            return insets;
-        });
 
         setupTabs();
         updateTabLayoutPosition();
@@ -248,9 +235,6 @@ public class MainFragment extends BaseFragment implements TabLayout.OnTabSelecte
         tabLayout.setTabRippleColor(ColorStateList.valueOf(iconColor).withAlpha(32));
         tabLayout.setTabIconTint(ColorStateList.valueOf(iconColor));
         tabLayout.setSelectedTabIndicatorColor(iconColor);
-
-        // Re-apply the nav-bar inset padding for the new position (added at bottom, cleared at top).
-        ViewCompat.requestApplyInsets(tabLayout);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -722,21 +722,6 @@ public final class VideoDetailFragment
         pageAdapter = new TabAdapter(getChildFragmentManager());
         binding.viewPager.setAdapter(pageAdapter);
         binding.tabLayout.setupWithViewPager(binding.viewPager);
-        // Edge-to-edge (targetSdk 35+): the bottom tab strip is laid out gravity=bottom, so without
-        // insets it sits behind the system navigation bar (tabs unclickable) and the pager's last
-        // item runs under it. Pad the tab strip by the nav-bar inset and grow the pager's bottom
-        // padding (its XML 48dp tab clearance) by the same amount so content clears both.
-        final int viewPagerBottomBase = binding.viewPager.getPaddingBottom();
-        ViewCompat.setOnApplyWindowInsetsListener(binding.tabLayout, (v, insets) -> {
-            final int navBottom = insets.getInsets(
-                    WindowInsetsCompat.Type.navigationBars()).bottom;
-            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(), navBottom);
-            binding.viewPager.setPadding(binding.viewPager.getPaddingLeft(),
-                    binding.viewPager.getPaddingTop(), binding.viewPager.getPaddingRight(),
-                    viewPagerBottomBase + navBottom);
-            return insets;
-        });
-        ViewCompat.requestApplyInsets(binding.tabLayout);
         updateStickyPlayerMode();
 
         binding.detailThumbnailRootLayout.requestFocus();

--- a/app/src/main/java/org/schabi/newpipe/settings/BaseFilterListActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/BaseFilterListActivity.java
@@ -63,6 +63,8 @@ public abstract class BaseFilterListActivity extends AppCompatActivity {
 
         recyclerView = findViewById(R.id.filter_list);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        // Edge-to-edge (targetSdk 35+): keep the bottom of the filter list above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(recyclerView);
 
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this);
         loadFilterItems();

--- a/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/SettingsActivity.java
@@ -106,6 +106,9 @@ public class SettingsActivity extends AppCompatActivity implements
         WindowInsetsHelper.applyStatusBarInsets(this,
                 settingsLayoutBinding.settingsToolbarLayout.toolbar,
                 settingsLayoutBinding.settingsFragmentHolder);
+        // Edge-to-edge (targetSdk 35+): keep the last preference entry on long, scrollable
+        // settings pages above the system navigation bar.
+        WindowInsetsHelper.applyNavigationBarInsets(settingsLayoutBinding.settingsFragmentHolder);
 
         if (restored) {
             // Restore state

--- a/app/src/main/java/org/schabi/newpipe/util/WindowInsetsHelper.java
+++ b/app/src/main/java/org/schabi/newpipe/util/WindowInsetsHelper.java
@@ -71,6 +71,24 @@ public final class WindowInsetsHelper {
         });
     }
 
+    /**
+     * Pads the bottom of a content view by the navigation-bar inset, so its last items stay above
+     * the system navigation bar in edge-to-edge (targetSdk 35+). Used on the main fragment holder
+     * so feed/search/channel/playlist lists are not drawn behind the nav bar.
+     */
+    public static void applyNavigationBarInsets(@NonNull final View content) {
+        final int initialLeft = content.getPaddingLeft();
+        final int initialTop = content.getPaddingTop();
+        final int initialRight = content.getPaddingRight();
+        final int initialBottom = content.getPaddingBottom();
+
+        ViewCompat.setOnApplyWindowInsetsListener(content, (view, insets) -> {
+            final Insets navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
+            view.setPadding(initialLeft, initialTop, initialRight, initialBottom + navBars.bottom);
+            return insets;
+        });
+    }
+
     private static int getActionBarSize(@NonNull final AppCompatActivity activity) {
         final TypedValue typedValue = new TypedValue();
         if (activity.getTheme().resolveAttribute(android.R.attr.actionBarSize, typedValue, true)) {

--- a/app/src/main/java/org/schabi/newpipe/views/BaseLoginWebViewActivity.java
+++ b/app/src/main/java/org/schabi/newpipe/views/BaseLoginWebViewActivity.java
@@ -7,6 +7,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import androidx.appcompat.app.AppCompatActivity;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.util.WindowInsetsHelper;
 
 public abstract class BaseLoginWebViewActivity extends AppCompatActivity {
 
@@ -18,6 +19,8 @@ public abstract class BaseLoginWebViewActivity extends AppCompatActivity {
         setContentView(R.layout.login_webview);
 
         webView = findViewById(R.id.login_webview);
+        // Edge-to-edge (targetSdk 35+): keep the bottom of the login page above the nav bar.
+        WindowInsetsHelper.applyNavigationBarInsets(webView);
         configureWebView();
         webView.setWebViewClient(createWebViewClient());
         loadLoginUrl();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,6 +25,7 @@
             android:layout_gravity="center_horizontal"
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
+            app:paddingBottomSystemWindowInsets="true"
             app:layout_behavior="org.schabi.newpipe.player.event.CustomBottomSheetBehavior" />
 
     </org.schabi.newpipe.views.FocusAwareCoordinator>


### PR DESCRIPTION
Context (bug report):

- https://github.com/InfinityLoop1308/PipePipe/issues/2491

Follow-up to the edge-to-edge / targetSdk 37 work in #52.

## Summary

In edge-to-edge (targetSdk 35+) the collapsed mini player drew behind the system navigation bar, so its controls were unreachable with 3-button navigation. This applies the system-window inset at the bottom-sheet level, so the mini player (and the detail tabs) stay above the nav bar.

## Problem

The player bottom sheet draws edge-to-edge. The collapsed mini player (`overlay_layout`, anchored to the bottom of the sheet) ended up behind the navigation bar:

```text
overlay_play_pause_button  bounds=[838,2248][943,2400]   # screen 1080x2400
navigationBars inset       = [0,2274][1080,2400]         # 3-button, 126px
```

So the controls sat in the nav-bar region and could not be tapped.

## Changes

- `activity_main.xml`: `app:paddingBottomSystemWindowInsets="true"` on the player bottom sheet, so `BottomSheetBehavior` pads the sheet content by the nav-bar inset and grows the collapsed peek by the same amount.
- `VideoDetailFragment`: removed the manual per-tab inset added in #52; the sheet-level inset now covers both the detail tabs and the mini player (avoids a double inset).

## Validation

My Pixel 8, Android 16, 3-button navigation: mini player controls and detail tabs sit above the nav bar; gesture navigation unaffected.

Known minor cosmetic: a faint title still shows behind the translucent nav bar in the collapsed state. Separate follow-up.
