### PR TITLE
fix(comments): avoid crash on back when the player goes to pop-up

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -939,17 +939,15 @@ public final class VideoDetailFragment
     }
 
     private boolean callCommentFragmentOnBack() {
-        final String currentPage = pageAdapter.getItemTitle(binding.viewPager.getCurrentItem());
+        final int currentItem = binding.viewPager.getCurrentItem();
+        final String currentPage = pageAdapter.getItemTitle(currentItem);
         if (COMMENTS_TAB_TAG.equals(currentPage)) {
-            final FragmentManager fm = getFM();
-            final Fragment fragment = fm
-                    .findFragmentById(R.id.fragment_container_view);
-            if (fragment instanceof BackPressable) {
-                if (fm.getBackStackEntryCount() > 1) {
-                    fm.popBackStack();
-                    return true;
-                }
-                return ((BackPressable) fragment).onBackPressed();
+            // Delegate to the comments tab itself: it owns the replies in its child FragmentManager
+            // and pops them on back. (Previously this popped the parent FM directly, which could
+            // recreate a comment fragment in a destroyed container -> crash when going to pop-up.)
+            final Fragment tab = pageAdapter.getItem(currentItem);
+            if (tab instanceof BackPressable) {
+                return ((BackPressable) tab).onBackPressed();
             }
         }
         return false;

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentReplyFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentReplyFragment.java
@@ -114,8 +114,9 @@ public class CommentReplyFragment extends BaseFragment implements BackPressable 
 
     @Override
     public boolean onBackPressed() {
-        final FragmentManager fm = getFM();
-        fm.popBackStack();
+        // Pop the FragmentManager this reply lives in (its container's child FM), matching where it
+        // was pushed, so back works and nothing is left referencing a destroyed container.
+        getParentFragmentManager().popBackStack();
         return true;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragment.java
@@ -58,7 +58,11 @@ public class CommentsFragment extends BaseListInfoFragment<CommentsInfoItem, Com
     @Override
     protected void onItemCallback(final InfoItem selectedItem) throws Exception {
         super.onItemCallback(selectedItem);
-        CommentsFragmentContainer.setFragment(getFM(), (CommentsInfoItem) selectedItem);
+        // Push the reply onto the FragmentManager this fragment lives in (its container's child FM),
+        // not the parent activity FM, so it's torn down with the container's view (avoids the
+        // "No view found for fragment_container_view" crash on back when the player goes to pop-up).
+        CommentsFragmentContainer.setFragment(getParentFragmentManager(),
+                (CommentsInfoItem) selectedItem);
     }
 
     public CommentsFragment() {

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragmentContainer.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/comments/CommentsFragmentContainer.java
@@ -12,6 +12,7 @@ import androidx.fragment.app.FragmentManager;
 
 import org.schabi.newpipe.BaseFragment;
 import org.schabi.newpipe.R;
+import org.schabi.newpipe.fragments.BackPressable;
 import org.schabi.newpipe.extractor.Page;
 import org.schabi.newpipe.extractor.comments.CommentsInfoItem;
 import org.schabi.newpipe.util.Constants;
@@ -19,7 +20,7 @@ import org.schabi.newpipe.util.Constants;
 import java.io.IOException;
 import java.util.Objects;
 
-public class CommentsFragmentContainer extends BaseFragment {
+public class CommentsFragmentContainer extends BaseFragment implements BackPressable {
 
     protected int serviceId = Constants.NO_SERVICE_ID;
     protected String url;
@@ -56,7 +57,7 @@ public class CommentsFragmentContainer extends BaseFragment {
             final Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_container, container, false);
         if (savedInstanceState == null) {
-            setFragment(getFM(), serviceId, url, name);
+            setFragment(getChildFragmentManager(), serviceId, url, name);
         }
         return view;
     }
@@ -73,7 +74,20 @@ public class CommentsFragmentContainer extends BaseFragment {
         this.serviceId = serviceId;
         this.url = url;
         this.name = name;
-        setFragment(getFM(), serviceId, url, name);
+        setFragment(getChildFragmentManager(), serviceId, url, name);
+    }
+
+    @Override
+    public boolean onBackPressed() {
+        // Replies are pushed onto our OWN child FragmentManager (tied to this fragment's view), so
+        // backing out of a reply pops here. When the view is gone (e.g. video sent to pop-up) the
+        // child FM is torn down with it, so there's no stale entry to recreate -> no crash on back.
+        final FragmentManager childFm = getChildFragmentManager();
+        if (childFm.getBackStackEntryCount() > 0) {
+            childFm.popBackStack();
+            return true;
+        }
+        return false;
     }
 
     public static void setFragment(


### PR DESCRIPTION
Context (bug report):

- https://github.com/InfinityLoop1308/PipePipe/issues/2493

## Summary

Exiting the player while a video plays in pop-up mode can crash the app. The comment/reply fragments were hosted on the parent `FragmentManager` instead of `CommentsFragmentContainer`'s own child FM, so they could outlive their container view and be recreated into a container that no longer exists.

## Problem

Reported crash (5.2.0-beta2, marked "only once"):

```text
java.lang.IllegalArgumentException: No view found for id 0x7f0a01b3
    (fragment_container_view) for fragment CommentsFragment{...}
    at androidx.fragment.app.FragmentStateManager.createView(...)
    at androidx.fragment.app.FragmentManager.popBackStackImmediate(...)
    at androidx.activity.OnBackPressedDispatcher.onBackPressed(...)
    at org.schabi.newpipe.MainActivity.onBackPressed(...)
```

`CommentsFragmentContainer` committed `CommentsFragment` / `CommentReplyFragment` via `getFM()` (the parent `FragmentManager`), not its own child FM. When the container view is destroyed (player sent to pop-up), the parent FM still references those fragments, so a back-stack pop recreates `CommentsFragment` in a `fragment_container_view` that no longer exists.

## Changes

- Host the comments + replies in `CommentsFragmentContainer`'s own child `FragmentManager` (tied to its view), so they are torn down with it.
- `CommentsFragmentContainer` implements `BackPressable` and pops its own child FM.
- `VideoDetailFragment.callCommentFragmentOnBack()` delegates the comments-tab back to the container instead of popping the parent FM directly.
- `CommentsFragment` / `CommentReplyFragment` push/pop on `getParentFragmentManager()` (the child FM they now live in).

## Validation

My Pixel 8, Android 16: comments load, open a reply, back returns to the list, pop-up + back, no crash, no regression.

The report marks this "only once" (intermittent), so the exact trigger is not reproducible on demand; this removes the structural cause (fragments can no longer be recreated in a destroyed container by this path).
