### PR TITLE
fix(player): show clear-queue confirmation when tapping a new video

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -996,14 +996,17 @@ public final class VideoDetailFragment
                                    @Nullable final String newUrl,
                                    @NonNull final String newTitle,
                                    @Nullable final PlayQueue newQueue) {
-        if (isPlayerAvailable() && newQueue != null && playQueue != null
-                && playQueue.getItem() != null && !playQueue.getItem().getUrl().equals(newUrl)) {
-            // Preloading can be disabled since playback is surely being replaced.
-            player.disablePreloadingOfCurrentTrack();
-        }
+        loadVideoIfUserConfirms(newUrl, () -> {
+            if (isPlayerAvailable() && newQueue != null && playQueue != null
+                    && playQueue.getItem() != null
+                    && !playQueue.getItem().getUrl().equals(newUrl)) {
+                // Preloading can be disabled since playback is surely being replaced.
+                player.disablePreloadingOfCurrentTrack();
+            }
 
-        setInitialData(newServiceId, newUrl, newTitle, newQueue);
-        startLoading(false, true);
+            setInitialData(newServiceId, newUrl, newTitle, newQueue);
+            startLoading(false, true);
+        });
     }
 
     private void prepareAndHandleInfoIfNeededAfterDelay(final StreamInfo info,
@@ -2510,12 +2513,41 @@ public final class VideoDetailFragment
 
     private void replaceQueueIfUserConfirms(final Runnable onAllow) {
         @Nullable final PlayQueue activeQueue = isPlayerAvailable() ? player.getPlayQueue() : null;
+        final boolean hasMultiItemQueue = activeQueue != null && activeQueue.size() > 1;
 
         // Player will have STATE_IDLE when a user pressed back button
         if (isClearingQueueConfirmationRequired(activity)
                 && playerIsNotStopped()
+                && hasMultiItemQueue
                 && activeQueue != null
                 && !activeQueue.equals(playQueue)) {
+            showClearingQueueConfirmation(onAllow);
+        } else {
+            onAllow.run();
+        }
+    }
+
+    /**
+     * Same purpose as {@link #replaceQueueIfUserConfirms(Runnable)}, but meant to be called
+     * before the new stream's data has been loaded (e.g. from {@link #selectAndLoadVideo}),
+     * i.e. before {@link #playQueue} has been updated to reflect the new target. Since
+     * {@link #playQueue} cannot be used for comparison yet, the queue currently playing in the
+     * active player is compared directly against the URL of the stream about to be loaded.
+     *
+     * @param newUrl  the url of the stream that is about to replace the active one, if confirmed
+     * @param onAllow the action to run once the navigation is allowed to proceed
+     */
+    private void loadVideoIfUserConfirms(@Nullable final String newUrl, final Runnable onAllow) {
+        @Nullable final PlayQueue activeQueue = isPlayerAvailable() ? player.getPlayQueue() : null;
+        @Nullable final PlayQueueItem activeItem =
+                activeQueue != null ? activeQueue.getItem() : null;
+        final boolean hasMultiItemQueue = activeQueue != null && activeQueue.size() > 1;
+
+        if (isClearingQueueConfirmationRequired(activity)
+                && playerIsNotStopped()
+                && hasMultiItemQueue
+                && activeItem != null
+                && !activeItem.getUrl().equals(newUrl)) {
             showClearingQueueConfirmation(onAllow);
         } else {
             onAllow.run();


### PR DESCRIPTION
## Summary
The "ask for confirmation before clearing a queue" setting only worked when switching the *same* video between player types (popup/background/main player), It never fired when tapping a *different* video.
The setting's actual main use case, whether from the feed, search results, or the related-items list under an expanded player.

## Problem
`selectAndLoadVideo()`, the entry point used whenever a different video is opened from any list, had no confirmation check of its own. The existing check (`replaceQueueIfUserConfirms`) only ran later, inside the autoplay path triggered after the new stream's info finished loading. By that point, `hideMainPlayerOnLoadingNewStream()` had already torn down the active player/queue (`playerHolder.stopService()`), so the check always saw `activeQueue == null` and silently skipped the confirmation — regardless of the setting.

## Changes
- Added `loadVideoIfUserConfirms()`, evaluated synchronously at the very top of `selectAndLoadVideo()`, before anything is torn down. It compares the *live* player's current queue item against the URL about to be loaded (since `playQueue`/`url` still reflect the *old* target at this point).
- Both confirmation checks (`replaceQueueIfUserConfirms` and the new `loadVideoIfUserConfirms`) now also require the active queue to have more than one item — replacing a lone, queue-less video just plays the new one immediately, no popup.

## Validation
Manually tested on-device (OnePlus Open):
- Play video A (no queue) → tap video B → plays immediately, no popup (size check working).
- Play video A → enqueue video B → tap video C from feed/search → confirmation popup now appears (previously did not).
- Same scenario but tapping a related item under the expanded player instead → popup also appears (same code path).
- Confirmed via verbose logging during development that, prior to the fix, the active queue was `null` by the time the original check ran.