### PR TITLE
fix(player): cover the navigation bar area in fullscreen so the feed doesn't show behind the player

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -226,6 +226,7 @@ public final class VideoDetailFragment
     private List<VideoStream> sortedVideoStreams;
     private int selectedVideoStreamIndex = -1;
     private int statusBarInset;
+    private int navigationBarInset;
     private BottomSheetBehavior<FrameLayout> bottomSheetBehavior;
     private BroadcastReceiver broadcastReceiver;
 
@@ -813,10 +814,15 @@ public final class VideoDetailFragment
                     WindowInsetsCompat.Type.statusBars()).top;
             statusBarInset = insets.getInsetsIgnoringVisibility(
                     WindowInsetsCompat.Type.statusBars()).top;
-            final int topPadding = isPlayerAvailable() && player.isFullscreen()
-                    ? 0 : statusBarHeight;
-            v.setPadding(v.getPaddingLeft(), topPadding,
-                    v.getPaddingRight(), v.getPaddingBottom());
+            final int navBarHeight = insets.getInsets(
+                    WindowInsetsCompat.Type.navigationBars()).bottom;
+            navigationBarInset = insets.getInsetsIgnoringVisibility(
+                    WindowInsetsCompat.Type.navigationBars()).bottom;
+            // In fullscreen the player must cover the whole screen, so drop both insets; otherwise
+            // keep the content above the status and navigation bars (mini player / detail, #53).
+            final boolean fullscreen = isPlayerAvailable() && player.isFullscreen();
+            v.setPadding(v.getPaddingLeft(), fullscreen ? 0 : statusBarHeight,
+                    v.getPaddingRight(), fullscreen ? 0 : navBarHeight);
             updateBottomSheetPeekHeight();
             return insets;
         });
@@ -2280,12 +2286,17 @@ public final class VideoDetailFragment
         addVideoPlayerView();
         final View bottomSheetLayout = requireActivity().findViewById(R.id.fragment_player_holder);
         if (fullscreen) {
+            // Cover the whole screen, including the navigation-bar area (no bottom strip, #2517).
             bottomSheetLayout.setPadding(bottomSheetLayout.getPaddingLeft(), 0,
-                    bottomSheetLayout.getPaddingRight(), bottomSheetLayout.getPaddingBottom());
+                    bottomSheetLayout.getPaddingRight(), 0);
         } else {
+            // Restore the system-bar insets so the mini player / detail stay above the bars (#53).
             bottomSheetLayout.setPadding(bottomSheetLayout.getPaddingLeft(), statusBarInset,
-                    bottomSheetLayout.getPaddingRight(), bottomSheetLayout.getPaddingBottom());
+                    bottomSheetLayout.getPaddingRight(), navigationBarInset);
         }
+        // Recompute the peek so the sheet content fills the screen in fullscreen (#2517);
+        // the inset listener that normally calls this does not re-fire on a fullscreen toggle.
+        updateBottomSheetPeekHeight();
     }
 
     @Override
@@ -2619,9 +2630,15 @@ public final class VideoDetailFragment
     }
 
     private void updateBottomSheetPeekHeight() {
+        // Grow the peek by the navigation-bar inset so the collapsed mini player sits above the nav
+        // bar (#2491); the holder is padded by the same inset (see the bottom-sheet inset listener).
         final int peekHeight = getResources().getDimensionPixelSize(R.dimen.mini_player_height)
-                + statusBarInset;
-        bottomSheetBehavior.setPeekHeight(bottomSheetState == BottomSheetBehavior.STATE_HIDDEN
+                + statusBarInset + navigationBarInset;
+        // In fullscreen the sheet is fully expanded and must cover the whole screen; a non-zero peek
+        // shrinks the sheet content by that amount, leaving an uncovered bottom strip (#2517).
+        final boolean fullscreen = isPlayerAvailable() && player.isFullscreen();
+        bottomSheetBehavior.setPeekHeight(
+                bottomSheetState == BottomSheetBehavior.STATE_HIDDEN || fullscreen
                 ? 0 : peekHeight);
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -25,7 +25,6 @@
             android:layout_gravity="center_horizontal"
             app:behavior_hideable="true"
             app:behavior_peekHeight="0dp"
-            app:paddingBottomSystemWindowInsets="true"
             app:layout_behavior="org.schabi.newpipe.player.event.CustomBottomSheetBehavior" />
 
     </org.schabi.newpipe.views.FocusAwareCoordinator>


### PR DESCRIPTION
Context (bug report):

- https://github.com/InfinityLoop1308/PipePipe/issues/2517

Follow-up to the edge-to-edge work in InfinityLoop1308/PipePipeClient#53.

## Summary

In fullscreen the player did not cover the navigation-bar area, so a strip at the bottom showed the feed behind it (Shorts, landscape and Bilibili vertical videos). This makes the player bottom-sheet inset handling fullscreen-aware: the player covers the whole screen in fullscreen, while the collapsed mini player still stays above the nav bar.

## Problem

The player bottom sheet used Material's `paddingBottomSystemWindowInsets`, which shrinks the sheet content by the system-bar insets and is not fullscreen-aware. In fullscreen the content stopped above the nav bar:

```text
fragment_player_holder  [0,0][1080,2400]
video_item_detail       [0,0][1080,2148]   # 252px short -> feed visible in [2148,2400]
```

## Changes

- `activity_main.xml`: drop `app:paddingBottomSystemWindowInsets` on the player holder.
- `VideoDetailFragment`: apply the status/navigation-bar insets manually and fullscreen-aware (holder padding + bottom-sheet peek): zero in fullscreen so the player fills the screen, the nav-bar inset otherwise so the mini player / detail stay above the bars.

## Validation

Pixel 8 emulator (API 36), 3-button navigation: in fullscreen the player now covers the whole screen (no feed strip at the bottom); the collapsed mini player still sits above the nav bar.
