### PR TITLE
fix(player): guard against a non-finite video aspect ratio crashing the player layout

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
+++ b/app/src/main/java/org/schabi/newpipe/views/ExpandableSurfaceView.java
@@ -70,8 +70,9 @@ public class ExpandableSurfaceView extends SurfaceView {
     @Override
     protected void onLayout(final boolean changed,
                             final int left, final int top, final int right, final int bottom) {
-        setScaleX(scaleX);
-        setScaleY(scaleY);
+        // Defensive: never push a non-finite scale into the view (it throws and takes down layout).
+        setScaleX(Float.isFinite(scaleX) ? scaleX : 1.0f);
+        setScaleY(Float.isFinite(scaleY) ? scaleY : 1.0f);
     }
 
     /**
@@ -102,11 +103,15 @@ public class ExpandableSurfaceView extends SurfaceView {
     }
 
     public void setAspectRatio(final float aspectRatio) {
-        if (videoAspectRatio == aspectRatio) {
+        // A 0x0 / not-yet-known video gives NaN (or Infinity) here; keep it as "no ratio" (0) so the
+        // measure path skips scaling instead of pushing NaN into setScaleX, which throws
+        // IllegalArgumentException and crashes the player during layout (#2515).
+        final float sanitized = Float.isFinite(aspectRatio) ? aspectRatio : 0.0f;
+        if (videoAspectRatio == sanitized) {
             return;
         }
 
-        videoAspectRatio = aspectRatio;
+        videoAspectRatio = sanitized;
         requestLayout();
     }
 }


### PR DESCRIPTION
Context (bug report):

- https://github.com/InfinityLoop1308/PipePipe/issues/2515

## Summary

I think this crash comes from a video with unknown / 0x0 dimensions: it yields a NaN (or Infinity) aspect ratio that becomes a non-finite scale passed to `View.setScaleX` during layout, which throws and crashes the player. This sanitizes the aspect ratio so the measure path skips scaling instead.

## Problem

```text
java.lang.IllegalArgumentException: Cannot set 'scaleX' to Float.NaN
    at android.view.View.setScaleX(View.java:20505)
    at org.schabi.newpipe.views.ExpandableSurfaceView.onLayout(...)
```

My read: `setAspectRatio` stores the raw ratio, and when it's NaN the `videoAspectRatio == 0` guard in `onMeasure` doesn't catch it (NaN != 0), so the scale ends up NaN and gets pushed into `setScaleX` during layout.

## Changes

- `ExpandableSurfaceView.setAspectRatio`: sanitize a non-finite aspect ratio to 0 ("no ratio"), so `onMeasure` skips scaling.
- `ExpandableSurfaceView.onLayout`: defensively never pass a non-finite scale to `setScaleX` / `setScaleY`.

## Validation

Honestly i couldn't reproduce the exact trigger on demand (it needs a 0x0 / not-yet-known video), so this is my best read of the stack trace plus a defensive guard rather than a measured before/after. The non-finite path looks like the only way a NaN reaches `setScaleX`, and both the source and the layout call are now guarded. If anyone can repro it i'm happy to confirm.
