### PR TITLE
fix(player): bound SABR memory during background playlist skips

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
@@ -114,8 +114,29 @@ final class SabrMediaPeriod implements MediaPeriod,
                 streamResetFlags[i] = true;
             }
         }
+        updateActiveTracks(selections);
         rebuildCompositeLoader();
         return positionUs;
+    }
+
+    private void updateActiveTracks(final ExoTrackSelection[] selections) {
+        boolean videoActive = false;
+        boolean audioActive = false;
+        for (final ExoTrackSelection selection : selections) {
+            if (selection == null) {
+                continue;
+            }
+            final int groupIndex = trackGroups.indexOf(selection.getTrackGroup());
+            if (groupIndex < 0) {
+                continue;
+            }
+            if (trackTypes[groupIndex] == C.TRACK_TYPE_VIDEO) {
+                videoActive = true;
+            } else if (trackTypes[groupIndex] == C.TRACK_TYPE_AUDIO) {
+                audioActive = true;
+            }
+        }
+        holder.setActiveTracks(videoActive, audioActive);
     }
 
     private ChunkSampleStream<SabrChunkSource> buildStream(final ExoTrackSelection selection,
@@ -256,6 +277,7 @@ final class SabrMediaPeriod implements MediaPeriod,
             s.release();
         }
         streams.clear();
+        holder.setActiveTracks(false, false);
     }
 
     /** No-op loader used before any track is selected. */

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -83,6 +83,7 @@ public final class SabrSessionStore {
         private final Set<Integer> activeReaderItags =
                 Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
         private volatile SabrStreamPump pump;
+        private volatile Thread warmThread;
 
         Holder(@NonNull final String videoId,
                @NonNull final YoutubeSabrInfo info,
@@ -158,6 +159,28 @@ public final class SabrSessionStore {
                 pump = new SabrStreamPump(session, this, localization);
             }
             return pump;
+        }
+
+        void setWarmThread(@NonNull final Thread warmThread) {
+            this.warmThread = warmThread;
+        }
+
+        void clearWarmThread(final Thread thread) {
+            if (warmThread == thread) {
+                warmThread = null;
+            }
+        }
+
+        void stop() {
+            setActiveTracks(false, false);
+            final Thread warm = warmThread;
+            if (warm != null && warm != Thread.currentThread()) {
+                warm.interrupt();
+            }
+            final SabrStreamPump streamPump = pump;
+            if (streamPump != null) {
+                streamPump.stop();
+            }
         }
 
         boolean isBeyondEnd(@NonNull final SabrSegmentRequest request) {
@@ -259,30 +282,38 @@ public final class SabrSessionStore {
                 }
             }
             // Pre-warm the PO token off-thread so the ~45s WebView mint overlaps the initial probe
-            // and buffering instead of stalling the pump on its first protected response.
+            // and buffering instead of stalling the pump on its first protected response. Keep the
+            // init preload off this creation path too: it is best-effort and can wait on the same
+            // protected request, so doing it synchronously lets playback teardown cancel source
+            // resolution before a MediaSource is returned.
+            final boolean preloadInit = preferredAudioTrackId != null || provider.hasCachedToken(videoId);
             final Thread warm = new Thread(() -> {
                 try {
+                    if (Thread.currentThread().isInterrupted() || !isCurrentHolder(videoId, holder)) {
+                        return;
+                    }
                     provider.getPoToken(info, session.getStreamState());
+                    if (Thread.currentThread().isInterrupted() || !isCurrentHolder(videoId, holder)) {
+                        return;
+                    }
+                    // Pre-load init metadata when a seek will follow (audio switch, or cold-restore:
+                    // a cached token means we played this recently). Else the seek maps with the
+                    // default 5000ms segment duration -> audio UnexpectedDiscontinuityException.
+                    if (preloadInit) {
+                        session.fetchSegment(SabrSegmentRequest.initialization(audioFormat),
+                                localization);
+                        session.fetchSegment(SabrSegmentRequest.initialization(videoFormat),
+                                localization);
+                    }
                 } catch (final Exception ignored) {
-                    // Best-effort; the pump mints on demand if this fails.
+                    // Best-effort; the pump mints/fetches on demand if this fails.
+                } finally {
+                    holder.clearWarmThread(Thread.currentThread());
                 }
             }, "SabrTokenPrewarm");
             warm.setDaemon(true);
+            holder.setWarmThread(warm);
             warm.start();
-            // Pre-load init metadata when a seek will follow (audio switch, or cold-restore: a
-            // cached token means we played this recently). Else the seek maps with the default
-            // 5000ms segment duration -> audio UnexpectedDiscontinuityException. The token gate keeps
-            // the first play (starts at 0) off the ~45s mint.
-            if (preferredAudioTrackId != null || provider.hasCachedToken(videoId)) {
-                try {
-                    session.fetchSegment(SabrSegmentRequest.initialization(audioFormat),
-                            localization);
-                    session.fetchSegment(SabrSegmentRequest.initialization(videoFormat),
-                            localization);
-                } catch (final Exception ignored) {
-                    // Best-effort; on failure the seek falls back to the previous behaviour.
-                }
-            }
             return holder;
         }
     }
@@ -382,9 +413,18 @@ public final class SabrSessionStore {
 
     /** Evict a cached session, stopping its pump so the thread + buffers are released. */
     public static void evict(@NonNull final String videoId) {
-        final Holder holder = SESSIONS.remove(videoId);
-        if (holder != null && holder.pump != null) {
-            holder.pump.stop();
+        final Holder holder;
+        synchronized (SabrSessionStore.class) {
+            holder = SESSIONS.remove(videoId);
+            ORDER.remove(videoId);
         }
+        if (holder != null) {
+            holder.stop();
+        }
+    }
+
+    private static boolean isCurrentHolder(@NonNull final String videoId,
+                                           @NonNull final Holder holder) {
+        return SESSIONS.get(videoId) == holder;
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -15,7 +15,9 @@ import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrInfo;
 import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrSession;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -76,6 +78,10 @@ public final class SabrSessionStore {
         // and eviction run on: it never goes stale (a stalled reader sits on its last segment, so the
         // pump sees edge ~= readerHead and keeps feeding instead of pacing off a frozen play head).
         private final Map<Integer, Long> readerPositions = new ConcurrentHashMap<>();
+        // Tracks currently selected by ExoPlayer. Background/audio-only playback disables the video
+        // renderer, so requiring a video reader position there pins the SABR cache at the beginning.
+        private final Set<Integer> activeReaderItags =
+                Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
         private volatile SabrStreamPump pump;
 
         Holder(@NonNull final String videoId,
@@ -103,29 +109,47 @@ public final class SabrSessionStore {
             readerPositions.put(itag, ms);
         }
 
-        /** Furthest-read track: the pump keeps the buffered edge a cushion ahead of THIS. */
+        void setActiveTracks(final boolean videoActive, final boolean audioActive) {
+            setTrackActive(videoFormat.getItag(), videoActive);
+            setTrackActive(audioFormat.getItag(), audioActive);
+        }
+
+        private void setTrackActive(final int itag, final boolean active) {
+            if (active) {
+                activeReaderItags.add(itag);
+            } else {
+                activeReaderItags.remove(itag);
+                readerPositions.remove(itag);
+            }
+        }
+
+        /** Furthest-read selected track: the pump keeps the buffered edge a cushion ahead of THIS. */
         public long getReaderHeadMs() {
             long head = 0;
-            final Long a = readerPositions.get(audioFormat.getItag());
-            final Long v = readerPositions.get(videoFormat.getItag());
-            if (a != null) {
-                head = Math.max(head, a);
-            }
-            if (v != null) {
-                head = Math.max(head, v);
+            for (final int itag : activeReaderItags) {
+                final Long position = readerPositions.get(itag);
+                if (position != null) {
+                    head = Math.max(head, position);
+                }
             }
             return head;
         }
 
-        /** Slowest-read track: nothing before this is needed any more, so eviction starts here. Zero
-         * until BOTH tracks have read something (else we'd evict the other track's unread segments). */
+        /** Slowest-read selected track: nothing before this is needed any more, so eviction starts here.
+         * Zero until every selected track has read something (else we'd evict unread segments). */
         public long getReaderTailMs() {
-            final Long a = readerPositions.get(audioFormat.getItag());
-            final Long v = readerPositions.get(videoFormat.getItag());
-            if (a == null || v == null) {
+            if (activeReaderItags.isEmpty()) {
                 return 0;
             }
-            return Math.min(a, v);
+            long tail = Long.MAX_VALUE;
+            for (final int itag : activeReaderItags) {
+                final Long position = readerPositions.get(itag);
+                if (position == null) {
+                    return 0;
+                }
+                tail = Math.min(tail, position);
+            }
+            return tail == Long.MAX_VALUE ? 0 : tail;
         }
 
         /** Lazily create the single background pump that feeds both data sources for this video. */

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/WebViewPoTokenProvider.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -112,11 +113,20 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
             if (cached != null && now - cached.mintedAtMs < TOKEN_TTL_MS) {
                 return cached.token;
             }
+            if (Thread.currentThread().isInterrupted()) {
+                return null;
+            }
             // One retry: the BotGuard mint occasionally times out, and a single null killed playback.
             String tokenB64 = mintBlocking(videoId);
+            if (Thread.currentThread().isInterrupted()) {
+                return null;
+            }
             if (tokenB64 == null || tokenB64.isEmpty()) {
                 Log.w(TAG, "PO token mint returned null, retrying once for " + videoId);
                 tokenB64 = mintBlocking(videoId);
+                if (Thread.currentThread().isInterrupted()) {
+                    return null;
+                }
             }
             if (tokenB64 == null || tokenB64.isEmpty()) {
                 return null;
@@ -178,12 +188,23 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
     @Nullable
     private String mintBlocking(final String videoId) {
         final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicBoolean canceled = new AtomicBoolean(false);
         final AtomicReference<String> tokenRef = new AtomicReference<>();
         final AtomicReference<WebView> webViewRef = new AtomicReference<>();
 
         mainHandler.post(() -> {
+            if (canceled.get()) {
+                latch.countDown();
+                return;
+            }
             try {
-                webViewRef.set(createWebView(videoId, tokenRef, latch));
+                final WebView webView = createWebView(videoId, tokenRef, latch, canceled);
+                if (canceled.get()) {
+                    destroyWebView(webView);
+                    latch.countDown();
+                } else {
+                    webViewRef.set(webView);
+                }
             } catch (final Exception e) {
                 Log.e(TAG, "failed to start WebView pipeline", e);
                 latch.countDown();
@@ -197,6 +218,7 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
         } finally {
+            canceled.set(true);
             mainHandler.post(() -> destroyWebView(webViewRef.getAndSet(null)));
         }
         return tokenRef.get();
@@ -205,13 +227,14 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
     @SuppressLint("SetJavaScriptEnabled")
     private WebView createWebView(final String videoId,
                                   final AtomicReference<String> tokenRef,
-                                  final CountDownLatch latch) {
+                                  final CountDownLatch latch,
+                                  final AtomicBoolean canceled) {
         final WebView webView = new WebView(appContext);
         final WebSettings settings = webView.getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setDomStorageEnabled(true);
         settings.setUserAgentString(DESKTOP_UA);
-        webView.addJavascriptInterface(new Bridge(tokenRef, latch), "SabrPocBridge");
+        webView.addJavascriptInterface(new Bridge(tokenRef, latch, canceled), "SabrPocBridge");
         webView.setWebViewClient(new WebViewClient() {
             private boolean injected = false;
 
@@ -228,19 +251,26 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
             @Override
             public void onPageFinished(final WebView view, final String url) {
                 super.onPageFinished(view, url);
-                if (injected || url == null || !url.contains("youtube.com")) {
+                if (canceled.get() || injected || url == null || !url.contains("youtube.com")) {
                     return;
                 }
                 injected = true;
-                waitForReadyThenInject(view, videoId, 0);
+                waitForReadyThenInject(view, videoId, 0, canceled);
             }
         });
         webView.loadUrl("https://www.youtube.com/");
         return webView;
     }
 
-    private void waitForReadyThenInject(final WebView view, final String videoId, final int attempt) {
+    private void waitForReadyThenInject(final WebView view, final String videoId, final int attempt,
+                                        final AtomicBoolean canceled) {
+        if (canceled.get()) {
+            return;
+        }
         view.evaluateJavascript("document.readyState", value -> {
+            if (canceled.get()) {
+                return;
+            }
             final boolean complete = value != null && value.contains("complete");
             if (complete || attempt >= READY_RETRIES) {
                 view.evaluateJavascript(
@@ -248,7 +278,8 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
                 view.evaluateJavascript(loadPipelineScript(), null);
             } else {
                 mainHandler.postDelayed(
-                        () -> waitForReadyThenInject(view, videoId, attempt + 1), READY_POLL_MS);
+                        () -> waitForReadyThenInject(view, videoId, attempt + 1, canceled),
+                        READY_POLL_MS);
             }
         });
     }
@@ -317,15 +348,21 @@ public final class WebViewPoTokenProvider implements SabrPoTokenProvider {
     private static final class Bridge {
         private final AtomicReference<String> tokenRef;
         private final CountDownLatch latch;
+        private final AtomicBoolean canceled;
 
-        Bridge(final AtomicReference<String> tokenRef, final CountDownLatch latch) {
+        Bridge(final AtomicReference<String> tokenRef, final CountDownLatch latch,
+               final AtomicBoolean canceled) {
             this.tokenRef = tokenRef;
             this.latch = latch;
+            this.canceled = canceled;
         }
 
         @JavascriptInterface
         public void onResult(final String json) {
             try {
+                if (canceled.get()) {
+                    return;
+                }
                 final JSONObject obj = new JSONObject(json);
                 if (obj.optBoolean("ok", false)) {
                     tokenRef.set(obj.optString("poToken", null));


### PR DESCRIPTION
Fixes https://github.com/InfinityLoop1308/PipePipe/issues/2577

Pairs with the extractor-side segment allocation fix: InfinityLoop1308/PipePipeExtractor#77

## Summary

SABR playback could hit an OOM when rapidly skipping through a large playlist, especially in background/audio-only playback.

There were two contributing problems:

- in background mode, the video renderer is disabled, but SABR eviction still waited for both audio and video reader positions;
- abandoned SABR prewarm/pump work could keep running after the session was no longer current.

This makes SABR eviction follow only the tracks currently selected by Media3, and stops stale prewarm work when a session is evicted.

## Problem

Issue #2577 reported OOMs while using SABR, mostly in background playlist playback.

On my Pixel 8 repro:

```text
playlist + SABR forced + background playback + rapid MEDIA_NEXT
```

Before the fix, the app hit OOM around skip 7:

```text
Throwing OutOfMemoryError "Failed to allocate ... target footprint 536870912, growth limit 536870912"
```

Root cause for the first memory growth path:

`Player.useVideoSource(false)` disables the video renderer in background/audio-only playback. But `SabrSessionStore.Holder.getReaderTailMs()` required both the audio and video reader positions before advancing eviction. The video reader never advanced in this mode, so SABR's play head stayed pinned near zero and old cached segments were not evicted.

A longer 120-skip run exposed a second allocation spike in the extractor segment collector, fixed in the paired extractor PR.

## Changes

- Track which SABR itags are actively selected by Media3 in `SabrMediaPeriod.selectTracks`.
- Drive `getReaderHeadMs()` / `getReaderTailMs()` from selected tracks only.
  - Foreground A/V playback still waits for both tracks.
  - Background audio-only playback evicts based on the audio reader.
- Clear active tracks on `SabrMediaPeriod.release()`.
- Move best-effort init preload fully off the source creation path.
- Track and interrupt `SabrTokenPrewarm` when its session is evicted.
- Make `WebViewPoTokenProvider` cancellation-aware so interrupted prewarm work does not start/retry stale WebView token mints.

## Validation

Build:

- `./gradlew :extractor:compileJava` in PipePipeExtractor
- `./gradlew :app:assembleDebug` in PipePipeClient

Device:

- Installed debug APK on Pixel 8.
- Confirmed `force_sabr=true`.
- Reproduced before the fix with:
  - `https://www.youtube.com/playlist?list=PLMC9KNkIncKtPzgY-5rmhvj7fax8fdxoj`
  - background playback
  - rapid `KEYCODE_MEDIA_NEXT`

Before:

```text
OOM around skip 7
Java heap RSS near 539 MB
```

Intermediate validation after active-track eviction:

```text
25 skip attempts
no OOM/FATAL
max Java heap RSS: 382692 KB
```

Long validation after the paired extractor fix:

```text
120 MEDIA_NEXT commands
MediaSourceManager: 100 source loads, 119 reloads
no OutOfMemory
no FATAL EXCEPTION
no Failed to allocate
max Java heap RSS: 149648 KB
```

## Notes

The MediaSession metadata stayed stale during part of the stress test, but `MediaSourceManager` logs confirmed that the player actually advanced through the playlist and loaded many different items. The validation target here is the SABR OOM path from #2577, not media-session metadata freshness.