### PR TITLE
fix(player): prefer plain SABR AAC audio variants

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -281,7 +281,9 @@ public final class SabrSessionStore {
     // with the way we chunk it, and i still have no fucking idea how to fix it. AAC (itag 140) is
     // mp4, hardware-decoded, ~same bitrate (130 vs 136 kbps) and plays perfectly smooth. so: AAC
     // until someone cracks the Opus path. (audio codec isn't user-facing, so this isn't a band-aid
-    // on a user setting, just an internal pick.)
+    // on a user setting, just an internal pick.) Prefer the plain AAC variant: YouTube can expose
+    // extra xtags variants (e.g. voice-boost) and DRC for the same itag; a tiny bitrate difference
+    // must not make gameplay/music sound compressed, warped, or volume-pumped.
     private static YoutubeSabrFormat pickAudioFormat(@NonNull final YoutubeSabrInfo info,
                                                      @Nullable final String preferredTrackId) {
         YoutubeSabrFormat aac = null;
@@ -304,19 +306,27 @@ public final class SabrSessionStore {
                         + " name=" + f.getAudioTrackDisplayName()
                         + " default=" + f.isAudioDefault()
                         + " original=" + f.isOriginalAudio()
+                        + " drc=" + f.isDrc()
+                        + " xtags=" + f.getXtags()
                         + " bitrate=" + f.getBitrate());
             }
             if (aac == null) {
                 aac = f;
                 continue;
             }
-            // Prefer the original-language track over an auto-dub, then the highest bitrate, so a
-            // dubbed default doesn't override the source audio. Falls back to plain highest-bitrate
-            // when no track is marked original (single-track videos).
+            // Prefer the original-language track over an auto-dub, then the plain/non-DRC stream,
+            // then bitrate. Voice-boost/DRC variants are speech-oriented and can be bad for music/SFX.
             final boolean preferForTrack = f.isOriginalAudio() && !aac.isOriginalAudio();
+            final boolean preferForPlain = f.isOriginalAudio() == aac.isOriginalAudio()
+                    && isPlainAudioVariant(f) && !isPlainAudioVariant(aac);
+            final boolean preferForDrc = f.isOriginalAudio() == aac.isOriginalAudio()
+                    && isPlainAudioVariant(f) == isPlainAudioVariant(aac)
+                    && !f.isDrc() && aac.isDrc();
             final boolean preferForBitrate = f.isOriginalAudio() == aac.isOriginalAudio()
+                    && isPlainAudioVariant(f) == isPlainAudioVariant(aac)
+                    && f.isDrc() == aac.isDrc()
                     && f.getBitrate() > aac.getBitrate();
-            if (preferForTrack || preferForBitrate) {
+            if (preferForTrack || preferForPlain || preferForDrc || preferForBitrate) {
                 aac = f;
             }
         }
@@ -325,6 +335,8 @@ public final class SabrSessionStore {
                     + " itag=" + aac.getItag()
                     + " trackId=" + aac.getAudioTrackId()
                     + " name=" + aac.getAudioTrackDisplayName()
+                    + " drc=" + aac.isDrc()
+                    + " xtags=" + aac.getXtags()
                     + " original=" + aac.isOriginalAudio());
         }
         if (aac == null && preferredTrackId != null) {
@@ -332,6 +344,11 @@ public final class SabrSessionStore {
             return pickAudioFormat(info, null);
         }
         return aac != null ? aac : info.findBestAudioFormat();
+    }
+
+    private static boolean isPlainAudioVariant(@NonNull final YoutubeSabrFormat format) {
+        final String xtags = format.getXtags();
+        return xtags == null || xtags.isEmpty();
     }
 
     /** Honour the user-selected quality when that format is present and hardware-decodable;


### PR DESCRIPTION
Fixes https://github.com/InfinityLoop1308/PipePipe/issues/2581

## Summary

Some YouTube SABR responses expose multiple AAC entries for the same audio itag/track. The player currently picks the highest-bitrate AAC variant, which can select speech-oriented variants such as voice boost instead of the plain audio stream.

This changes SABR audio selection to prefer the original track first, then the plain AAC variant, then non-DRC, then bitrate.

## Problem

The reported video exposes several `itag=140` AAC formats for the same audio:

```text
plain:       itag=140 br=144222 drc=false xtags=null
DRC:         itag=140 br=144222 drc=true  xtags=...drc=1
voice boost: itag=140 br=144487 drc=false xtags=...vb=1
```

Before this change, the tiny bitrate difference made the player pick the `vb=1` variant. That matches the reported symptoms: voices remain understandable, but music/SFX can sound muffled, stretched, compressed, or volume-pumped.

## Changes

- Keep the existing AAC preference for SABR playback.
- Prefer original-language audio over auto-dub tracks.
- Prefer plain AAC variants where `xtags` is absent/empty.
- Prefer non-DRC variants over DRC variants.
- Use bitrate only as the final tiebreaker.
- Extend local diagnostic audio logs with `drc` and `xtags`.

## Validation

- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew :app:assembleDebug`
- `git diff --check`

Device validation on Pixel 8:

- Installed debug APK.
- Confirmed `force_sabr=true`.
- Tested the reported video:
  - `https://youtube.com/watch?v=s4MiZG5S5tU&t=14158`
  - DELTARUNE CHAPTER 5 gameplay, reported stage-clear section.
- Playback from start reaches `PLAYING`.
- Internal seek to `14158s` buffers briefly, then reaches `PLAYING` around `14154s`.
- No `OutOfMemory`.
- No `SABR pump fatal`.
- No ExoPlayer playback error.

## Notes

The fix is client-side only. It does not change SABR request flow, cache policy, or extractor parsing. It only avoids selecting YouTube's speech-oriented AAC variants when a plain AAC stream is available.
