### PR TITLE
fix(download): refuse SABR streams instead of crashing post-processing

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
+++ b/app/src/main/java/org/schabi/newpipe/download/DownloadDialog.java
@@ -52,6 +52,7 @@ import org.schabi.newpipe.extractor.exceptions.ParsingException;
 import org.schabi.newpipe.extractor.exceptions.ReCaptchaException;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.stream.AudioStream;
+import org.schabi.newpipe.extractor.stream.DeliveryMethod;
 import org.schabi.newpipe.extractor.stream.Stream;
 import org.schabi.newpipe.extractor.stream.StreamInfo;
 import org.schabi.newpipe.extractor.stream.SubtitlesStream;
@@ -1098,6 +1099,17 @@ public class DownloadDialog extends DialogFragment
             return;
         }
 
+        // SABR streams carry a serverAbrStreamingUrl as their "content", which is a POST endpoint
+        // for session-based playback, not a downloadable file. GET on it returns UMP or 4xx, and
+        // the resulting garbage fails WebMReader/Mp4DashReader during post-processing (#2569).
+        // Refuse cleanly so the user gets a clear message instead of a hard crash.
+        if (isSabrStream(selectedStream)
+                || (secondaryStream != null && isSabrStream(secondaryStream))) {
+            Toast.makeText(context, R.string.sabr_download_not_supported,
+                    Toast.LENGTH_LONG).show();
+            return;
+        }
+
         if (secondaryStream == null) {
             urls = new String[]{
                     selectedStream.getContent()
@@ -1134,5 +1146,14 @@ public class DownloadDialog extends DialogFragment
                 Toast.LENGTH_SHORT).show();
 
         dismiss();
+    }
+
+    /**
+     * Returns true when the stream uses SABR delivery, which the downloader can't handle
+     * (issue #2569). SABR streams carry a {@code serverAbrStreamingUrl} as their "content",
+     * which is the SABR POST endpoint for session-based playback, not a downloadable file.
+     */
+    private static boolean isSabrStream(@NonNull final Stream stream) {
+        return stream.getDeliveryMethod() == DeliveryMethod.SABR;
     }
 }

--- a/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
+++ b/app/src/main/java/us/shandian/giga/get/DirectDownloader.java
@@ -263,6 +263,17 @@ public class DirectDownloader {
                     new MissionRecoveryInfo(secondaryStream)};
         }
 
+        // SABR streams carry a serverAbrStreamingUrl as their "content", which is a POST endpoint
+        // for session-based playback, not a downloadable file. GET on it returns UMP or 4xx, and
+        // the resulting garbage fails WebMReader/Mp4DashReader during post-processing (issue
+        // #2569). Refuse the download so the caller (StreamProcessor) reports a clean failure
+        // instead of a stack trace mid-download.
+        if (selectedStream.getDeliveryMethod() == DeliveryMethod.SABR
+                || (secondaryStream != null
+                && secondaryStream.getDeliveryMethod() == DeliveryMethod.SABR)) {
+            throw new RuntimeException(context.getString(R.string.sabr_download_not_supported));
+        }
+
         resourceDeliveryMethods = HlsDownloadStreamHelper
                 .buildResourceDeliveryMethods(selectedStream, secondaryStream);
         resourceManifestUrls = HlsDownloadStreamHelper

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -773,6 +773,7 @@
 <string name="night_theme_summary">Select your favorite night theme — %s</string>
 <string name="select_night_theme_toast">You can select your favorite night theme below</string>
 <string name="download_has_started">Download has started</string>
+<string name="sabr_download_not_supported">SABR streams cannot be downloaded yet. Disable Force SABR, reopen the video, and try again.</string>
 <string name="description_select_note">You can now select text inside the description. Note that the page may flicker and links may not be clickable while in selection mode.</string>
 <string name="description_select_enable">Enable selecting text in the description</string>
 <string name="description_select_disable">Disable selecting text in the description</string>


### PR DESCRIPTION
Fixes https://github.com/InfinityLoop1308/PipePipe/issues/2569

## Summary

Force SABR currently exposes YouTube streams with `DeliveryMethod.SABR`, but the download stack still expects normal downloadable resources.

This PR refuses SABR downloads early in both the normal download dialog and the playlist/batch download path, with a clear message instead of letting the current downloader crash during post-processing.

## Problem

SABR streams are not direct media URLs.

When Force SABR is enabled, the extractor exposes audio/video streams whose `content` is the `serverAbrStreamingUrl`. That URL is the SABR session endpoint used by playback. It is not a plain WebM/MP4/DASH resource that the downloader can `GET` and pass to `WebMReader` or `Mp4DashReader`.

Before this change, the downloader could start a mission with that SABR endpoint anyway. The downloaded bytes were then not a valid WebM/MP4 resource, so post-processing failed with errors like:

```text
java.util.NoSuchElementException: expected 0xa45dfa3 found ...
    at org.schabi.newpipe.streams.WebMReader.parse(...)
```

There is also a cache-related variant of the same bug: if a video was opened while Force SABR was enabled, its `StreamInfo` can stay in `InfoCache` for a while. Disabling Force SABR after that does not necessarily refresh the already cached stream list immediately, so the download dialog may still receive SABR streams.

## Changes

- Detect `DeliveryMethod.SABR` before starting a normal single-video download.
- Detect `DeliveryMethod.SABR` before starting playlist/batch downloads through `DirectDownloader`.
- Show a clear user-facing message for the visible download dialog.
- Fail the batch download item cleanly instead of letting it crash later in post-processing.
- Add one shared string for the unsupported SABR download message.

## Validation

Build:

- `./gradlew :app:compileDebugJavaWithJavac`
- `./gradlew :app:assembleDebug`
- `git diff --check`

Local code validation:

- Applied on top of current `upstream/dev` / `v5.2.1-beta2`.
- Patch applies cleanly after the recent upstream changes.
- Verified the guard covers:
  - selected video stream is SABR
  - secondary audio stream is SABR
  - selected audio-only stream is SABR
  - stale cached `StreamInfo` still exposing SABR streams after Force SABR was disabled

## Notes

This is intentionally not the real SABR download implementation.

A proper SABR downloader is coming, but it needs more implementation and a lot more testing. It cannot just reuse the current direct downloader path. It needs to drive a `YoutubeSabrSession`, request the selected audio/video formats, collect init/media segments, write or mux them correctly, and handle the same SABR session/protection behavior that playback already has to deal with.

So this PR only closes the crashy unsupported path for now. Users still need to disable Force SABR and reopen the video with fresh non-SABR streams if they want to download before real SABR download support lands.
