### PR TITLE
fix(player): stabilize SABR playback memory

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrChunkSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrChunkSource.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.player.datasource;
 
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
@@ -15,6 +16,7 @@ import androidx.media3.exoplayer.source.chunk.ChunkExtractor;
 import androidx.media3.exoplayer.source.chunk.ChunkHolder;
 import androidx.media3.exoplayer.source.chunk.ChunkSource;
 import androidx.media3.exoplayer.source.chunk.ContainerMediaChunk;
+import androidx.media3.exoplayer.source.chunk.InitializationChunk;
 import androidx.media3.exoplayer.source.chunk.MediaChunk;
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy;
 import androidx.media3.extractor.Extractor;
@@ -36,12 +38,14 @@ import java.util.List;
  * then each media segment is a {@link ContainerMediaChunk}.
  */
 final class SabrChunkSource implements ChunkSource {
+    private static final String TAG = "SabrChunkSource";
 
     private final SabrSessionStore.Holder holder;
     private final YoutubeSabrFormat format;
     private final Format trackFormat;
     private final int trackType;
     private final Localization localization;
+    private final ChunkExtractor extractor;
 
     @Nullable
     private IOException fatalError;
@@ -56,6 +60,11 @@ final class SabrChunkSource implements ChunkSource {
         this.trackFormat = trackFormat;
         this.trackType = trackType;
         this.localization = localization;
+        final String mime = format.getMimeType();
+        final Extractor extractorImpl = mime != null && mime.contains("webm")
+                ? new MatroskaExtractor(SubtitleParser.Factory.UNSUPPORTED)
+                : new FragmentedMp4Extractor(SubtitleParser.Factory.UNSUPPORTED);
+        this.extractor = new BundledChunkExtractor(extractorImpl, trackType, trackFormat);
     }
 
     @Override
@@ -89,6 +98,16 @@ final class SabrChunkSource implements ChunkSource {
     @Override
     public void getNextChunk(final LoadingInfo loadingInfo, final long loadPositionUs,
                              final List<? extends MediaChunk> queue, final ChunkHolder out) {
+        if (extractor.getSampleFormats() == null) {
+            Log.d(TAG, "nextInit video=" + holder.videoId
+                    + " itag=" + format.getItag());
+            out.chunk = new InitializationChunk(
+                    new SabrSegmentDataSource(holder, format, localization,
+                            /* prependInit= */ false),
+                    new DataSpec(Uri.parse("sabrseg://" + format.getItag() + "/init")),
+                    trackFormat, C.SELECTION_REASON_UNKNOWN, null, extractor);
+            return;
+        }
         final int nextSeq;
         if (queue.isEmpty()) {
             nextSeq = holder.session.getStreamState()
@@ -98,9 +117,16 @@ final class SabrChunkSource implements ChunkSource {
         }
         final long endSeq = holder.session.getStreamState().getEndSegment(format);
         if (endSeq > 0 && nextSeq > endSeq) {
+            Log.d(TAG, "endOfStream video=" + holder.videoId
+                    + " itag=" + format.getItag() + " seq=" + nextSeq);
             out.endOfStream = true;
             return;
         }
+        Log.d(TAG, "nextChunk video=" + holder.videoId
+                + " itag=" + format.getItag()
+                + " seq=" + nextSeq
+                + " loadPositionUs=" + loadPositionUs
+                + " queue=" + queue.size());
         out.chunk = newMediaChunk(nextSeq);
     }
 
@@ -110,17 +136,8 @@ final class SabrChunkSource implements ChunkSource {
         final long startUs = Math.max(0, startMs) * 1000;
         final long endUs = (endMs > 0 ? endMs : startMs) * 1000;
         final DataSpec spec = new DataSpec(Uri.parse("sabrseg://" + format.getItag() + "/" + seq));
-        // Fresh extractor per chunk: the data source prepends the init, so each chunk is a complete
-        // init + one fragment. Absolute fragment timestamps -> sampleOffsetUs = 0. Pick the container
-        // by mime: YouTube ships VP9/Opus in WebM (Matroska) and AVC/AAC in fragmented mp4.
-        final String mime = format.getMimeType();
-        final Extractor extractorImpl = mime != null && mime.contains("webm")
-                ? new MatroskaExtractor(SubtitleParser.Factory.UNSUPPORTED)
-                : new FragmentedMp4Extractor(SubtitleParser.Factory.UNSUPPORTED);
-        final ChunkExtractor extractor = new BundledChunkExtractor(
-                extractorImpl, trackType, trackFormat);
         return new ContainerMediaChunk(
-                new SabrSegmentDataSource(holder, format, localization, /* prependInit= */ true),
+                new SabrSegmentDataSource(holder, format, localization, /* prependInit= */ false),
                 spec, trackFormat, C.SELECTION_REASON_UNKNOWN, null,
                 startUs, endUs, /* clippedStartTimeUs= */ startUs,
                 // No end clip, on purpose. The first chunk's declared end is basically a rumor: we

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.player.datasource;
 
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import androidx.media3.common.C;
@@ -34,6 +36,7 @@ import java.util.List;
  */
 final class SabrMediaPeriod implements MediaPeriod,
         SequenceableLoader.Callback<ChunkSampleStream<SabrChunkSource>> {
+    private static final String TAG = "SabrMediaPeriod";
 
     private final SabrSessionStore.Holder holder;
     private final Localization localization;
@@ -75,11 +78,15 @@ final class SabrMediaPeriod implements MediaPeriod,
         this.trackGroups = new TrackGroupArray(
                 new TrackGroup("sabr-video", videoFormat),
                 new TrackGroup("sabr-audio", audioFormat));
+        Log.d(TAG, "create period video=" + holder.videoId
+                + " videoItag=" + holder.videoFormat.getItag()
+                + " audioItag=" + holder.audioFormat.getItag());
     }
 
     @Override
     public void prepare(final MediaPeriod.Callback cb, final long positionUs) {
         this.callback = cb;
+        Log.d(TAG, "prepare video=" + holder.videoId + " positionUs=" + positionUs);
         cb.onPrepared(this);
     }
 
@@ -96,6 +103,8 @@ final class SabrMediaPeriod implements MediaPeriod,
     public long selectTracks(final ExoTrackSelection[] selections, final boolean[] mayRetainFlags,
                              final SampleStream[] outStreams, final boolean[] streamResetFlags,
                              final long positionUs) {
+        Log.d(TAG, "selectTracks video=" + holder.videoId
+                + " selections=" + selections.length + " positionUs=" + positionUs);
         // Release streams no longer wanted; create streams for newly selected tracks.
         for (int i = 0; i < selections.length; i++) {
             if (outStreams[i] instanceof ChunkSampleStream && (selections[i] == null
@@ -137,6 +146,8 @@ final class SabrMediaPeriod implements MediaPeriod,
             }
         }
         holder.setActiveTracks(videoActive, audioActive);
+        Log.d(TAG, "activeTracks video=" + holder.videoId
+                + " video=" + videoActive + " audio=" + audioActive);
     }
 
     private ChunkSampleStream<SabrChunkSource> buildStream(final ExoTrackSelection selection,
@@ -144,6 +155,11 @@ final class SabrMediaPeriod implements MediaPeriod,
         final TrackGroup group = selection.getTrackGroup();
         final int groupIndex = trackGroups.indexOf(group);
         final Format trackFormat = group.getFormat(0);
+        Log.d(TAG, "buildStream video=" + holder.videoId
+                + " groupIndex=" + groupIndex
+                + " trackType=" + trackTypes[groupIndex]
+                + " itag=" + sabrFormats[groupIndex].getItag()
+                + " positionUs=" + positionUs);
         final SabrChunkSource chunkSource = new SabrChunkSource(holder, sabrFormats[groupIndex],
                 trackFormat, trackTypes[groupIndex], localization);
         // Last 3 args are new in media3 1.10 (handleInitialDiscontinuity, firstChunkStartTimeUs,
@@ -273,6 +289,7 @@ final class SabrMediaPeriod implements MediaPeriod,
     }
 
     void release() {
+        Log.d(TAG, "release period video=" + holder.videoId);
         for (final ChunkSampleStream<SabrChunkSource> s : streams) {
             s.release();
         }

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaSource.java
@@ -1,5 +1,7 @@
 package org.schabi.newpipe.player.datasource;
 
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import androidx.media3.common.Format;
@@ -22,6 +24,7 @@ import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrFormat;
  * time-based and lands correctly. The session is created by the resolver and handed in.
  */
 public final class SabrMediaSource extends BaseMediaSource {
+    private static final String TAG = "SabrMediaSource";
 
     private final MediaItem mediaItem;
     private final SabrSessionStore.Holder holder;
@@ -29,6 +32,7 @@ public final class SabrMediaSource extends BaseMediaSource {
     private final Format audioFormat;
     private final Format videoFormat;
     private final long durationUs;
+    private boolean released;
 
     public SabrMediaSource(final MediaItem mediaItem,
                            final SabrSessionStore.Holder holder,
@@ -36,6 +40,8 @@ public final class SabrMediaSource extends BaseMediaSource {
         this.mediaItem = mediaItem;
         this.holder = holder;
         this.localization = localization;
+        this.holder.retainSource();
+        Log.d(TAG, "create source video=" + holder.videoId);
         this.audioFormat = toMedia3Format(holder.audioFormat);
         this.videoFormat = toMedia3Format(holder.videoFormat);
         this.durationUs = Math.max(holder.audioFormat.getApproxDurationMs(),
@@ -61,6 +67,7 @@ public final class SabrMediaSource extends BaseMediaSource {
     @Override
     public MediaPeriod createPeriod(final MediaPeriodId id, final Allocator allocator,
                                     final long startPositionUs) {
+        Log.d(TAG, "createPeriod video=" + holder.videoId + " startUs=" + startPositionUs);
         return new SabrMediaPeriod(holder, audioFormat, videoFormat, durationUs, allocator,
                 DrmSessionManager.DRM_UNSUPPORTED, createDrmEventDispatcher(id),
                 createEventDispatcher(id), localization);
@@ -68,11 +75,17 @@ public final class SabrMediaSource extends BaseMediaSource {
 
     @Override
     public void releasePeriod(final MediaPeriod mediaPeriod) {
+        Log.d(TAG, "releasePeriod video=" + holder.videoId);
         ((SabrMediaPeriod) mediaPeriod).release();
     }
 
     @Override
     protected void releaseSourceInternal() {
+        if (!released) {
+            released = true;
+            Log.d(TAG, "release source video=" + holder.videoId);
+            holder.releaseSource();
+        }
     }
 
     private static Format toMedia3Format(final YoutubeSabrFormat f) {

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSegmentDataSource.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSegmentDataSource.java
@@ -1,6 +1,7 @@
 package org.schabi.newpipe.player.datasource;
 
 import android.net.Uri;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
@@ -9,12 +10,17 @@ import androidx.media3.datasource.DataSource;
 import androidx.media3.datasource.DataSpec;
 import androidx.media3.datasource.TransferListener;
 
+import org.schabi.newpipe.extractor.NewPipe;
+import org.schabi.newpipe.extractor.downloader.Response;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.services.youtube.sabr.SabrMediaSegment;
 import org.schabi.newpipe.extractor.services.youtube.sabr.SabrSegmentRequest;
 import org.schabi.newpipe.extractor.services.youtube.sabr.YoutubeSabrFormat;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Tier-2 chunk source helper: a {@link DataSource} that serves exactly ONE SABR segment (the init
@@ -27,6 +33,7 @@ import java.io.IOException;
  * {@code sabrseg://<itag>/<sequenceNumber>}.</p>
  */
 public final class SabrSegmentDataSource implements DataSource {
+    private static final String TAG = "SabrSegmentDataSource";
 
     private static final long WAIT_MS = 250;
     private static final long STALL_MS = 120_000;
@@ -75,8 +82,14 @@ public final class SabrSegmentDataSource implements DataSource {
         this.canceled = false;
         this.pos = (int) Math.max(0, dataSpec.position);
         final SabrSegmentRequest request = requestFromUri(dataSpec.uri);
-        if (prependInit && !request.isInitializationSegment()) {
-            final byte[] init = awaitSegment(SabrSegmentRequest.initialization(format));
+        Log.d(TAG, "open video=" + holder.videoId
+                + " itag=" + format.getItag()
+                + " uri=" + dataSpec.uri
+                + " prependInit=" + prependInit);
+        if (request.isInitializationSegment()) {
+            this.data = getInitializationData();
+        } else if (prependInit) {
+            final byte[] init = getInitializationData();
             final byte[] media = awaitSegment(request);
             final byte[] both = new byte[init.length + media.length];
             System.arraycopy(init, 0, both, 0, init.length);
@@ -87,7 +100,60 @@ public final class SabrSegmentDataSource implements DataSource {
         }
         this.opened = true;
         final int remaining = data.length - pos;
+        Log.d(TAG, "opened video=" + holder.videoId
+                + " itag=" + format.getItag()
+                + " bytes=" + data.length
+                + " remaining=" + remaining);
         return dataSpec.length == C.LENGTH_UNSET ? remaining : Math.min(dataSpec.length, remaining);
+    }
+
+    private byte[] getInitializationData() throws IOException {
+        final int itag = format.getItag();
+        final byte[] cached = holder.getInitializationData(itag);
+        if (cached != null) {
+            return cached;
+        }
+        final SabrMediaSegment segment =
+                holder.session.getCachedSegment(SabrSegmentRequest.initialization(format));
+        if (segment != null) {
+            final byte[] data = segment.getData();
+            holder.setInitializationData(itag, data);
+            return data;
+        }
+        final String url = format.getInitializationUrl();
+        final long start = format.getInitRangeStart();
+        final long end = format.getInitRangeEnd();
+        if (url == null || url.isEmpty() || start < 0 || end < start) {
+            return awaitSegment(SabrSegmentRequest.initialization(format));
+        }
+
+        final String range = "bytes=" + start + "-" + end;
+        final Response response;
+        try {
+            response = NewPipe.getDownloader().get(url,
+                    Collections.singletonMap("Range", Collections.singletonList(range)));
+        } catch (final Exception e) {
+            throw new IOException("Could not fetch SABR init for itag=" + itag, e);
+        }
+        final byte[] data = response.rawResponseBody();
+        if (response.responseCode() != 206 && response.responseCode() != 200) {
+            throw new IOException("Could not fetch SABR init for itag=" + itag
+                    + ": HTTP " + response.responseCode());
+        }
+        if (data == null || data.length == 0) {
+            throw new IOException("Empty SABR init for itag=" + itag);
+        }
+        final long expectedLength = end - start + 1;
+        if (data.length > Math.max(expectedLength * 2, 1024 * 1024)) {
+            throw new IOException("Unexpectedly large SABR init for itag=" + itag
+                    + ": " + data.length + " bytes");
+        }
+        Log.d(TAG, "fetched init video=" + holder.videoId
+                + " itag=" + itag
+                + " bytes=" + data.length
+                + " range=" + range);
+        holder.setInitializationData(itag, data);
+        return data;
     }
 
     @Override
@@ -125,6 +191,7 @@ public final class SabrSegmentDataSource implements DataSource {
         final SabrStreamPump pump = holder.getPump(localization);
         final long waitStart = System.currentTimeMillis();
         long lastRefetchMs = 0;
+        boolean loggedWait = false;
         while (true) {
             if (canceled) {
                 throw new IOException("SABR segment read canceled");
@@ -132,6 +199,11 @@ public final class SabrSegmentDataSource implements DataSource {
             pump.ensureStarted();
             final SabrMediaSegment segment = pump.getCached(request);
             if (segment != null) {
+                Log.d(TAG, "cache hit video=" + holder.videoId
+                        + " itag=" + format.getItag()
+                        + " init=" + request.isInitializationSegment()
+                        + " seq=" + request.getSequenceNumber()
+                        + " bytes=" + segment.getData().length);
                 if (!segment.getHeader().isInitSegment()) {
                     // Tell the pump how far this track has been loaded so it keeps feeding ahead
                     // (and repositions after a seek). Without this readerHead stayed 0 and the pump
@@ -143,6 +215,15 @@ public final class SabrSegmentDataSource implements DataSource {
             }
             if (pump.isFatal()) {
                 throw new IOException("SABR pump fatal for itag=" + format.getItag());
+            }
+            if (!loggedWait && System.currentTimeMillis() - waitStart > 1000) {
+                loggedWait = true;
+                Log.d(TAG, "waiting video=" + holder.videoId
+                        + " itag=" + format.getItag()
+                        + " init=" + request.isInitializationSegment()
+                        + " seq=" + request.getSequenceNumber()
+                        + " edgeMs=" + holder.session.getStreamState().getMinBufferedEndMs()
+                        + " readerHeadMs=" + holder.getReaderHeadMs());
             }
             // Backward seek to an evicted segment behind the buffered edge: the forward pump never
             // re-fetches it, so it would never arrive. Drop our read position onto it (so eviction +

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Caches one shared {@link YoutubeSabrSession} per videoId so the audio and video
@@ -28,9 +29,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>v1: uses the best audio/video formats from the player response and a fixed en/US locale.</p>
  */
 public final class SabrSessionStore {
-
-    // Debug: log the AAC audio-track candidates + the chosen one. Keep false outside debugging.
-    private static final boolean DIAG_AUDIO = false;
 
     private static final Map<String, Holder> SESSIONS = new ConcurrentHashMap<>();
     // The user-selected audio track id per video, applied on the next (re)build of its session.
@@ -78,10 +76,12 @@ public final class SabrSessionStore {
         // and eviction run on: it never goes stale (a stalled reader sits on its last segment, so the
         // pump sees edge ~= readerHead and keeps feeding instead of pacing off a frozen play head).
         private final Map<Integer, Long> readerPositions = new ConcurrentHashMap<>();
+        private final Map<Integer, byte[]> initializationData = new ConcurrentHashMap<>();
         // Tracks currently selected by ExoPlayer. Background/audio-only playback disables the video
         // renderer, so requiring a video reader position there pins the SABR cache at the beginning.
         private final Set<Integer> activeReaderItags =
                 Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
+        private final AtomicInteger sourceReferences = new AtomicInteger();
         private volatile SabrStreamPump pump;
         private volatile Thread warmThread;
 
@@ -113,6 +113,25 @@ public final class SabrSessionStore {
         void setActiveTracks(final boolean videoActive, final boolean audioActive) {
             setTrackActive(videoFormat.getItag(), videoActive);
             setTrackActive(audioFormat.getItag(), audioActive);
+        }
+
+        byte[] getInitializationData(final int itag) {
+            return initializationData.get(itag);
+        }
+
+        void setInitializationData(final int itag, @NonNull final byte[] data) {
+            initializationData.put(itag, data);
+        }
+
+        void retainSource() {
+            sourceReferences.incrementAndGet();
+        }
+
+        void releaseSource() {
+            final int refs = sourceReferences.decrementAndGet();
+            if (refs <= 0) {
+                evict(videoId, this);
+            }
         }
 
         private void setTrackActive(final int itag, final boolean active) {
@@ -178,8 +197,11 @@ public final class SabrSessionStore {
                 warm.interrupt();
             }
             final SabrStreamPump streamPump = pump;
+            pump = null;
             if (streamPump != null) {
                 streamPump.stop();
+            } else {
+                session.clearCache();
             }
         }
 
@@ -226,9 +248,6 @@ public final class SabrSessionStore {
      */
     public static void setPreferredAudioTrack(@NonNull final String videoId,
                                               @Nullable final String audioTrackId) {
-        if (DIAG_AUDIO) {
-            System.out.println("SABR-AUDIO setPreferred video=" + videoId + " track=" + audioTrackId);
-        }
         if (audioTrackId == null) {
             PREFERRED_AUDIO.remove(videoId);
         } else {
@@ -239,6 +258,14 @@ public final class SabrSessionStore {
     public static Holder getOrCreate(@NonNull final Context context,
                                      @NonNull final String videoId,
                                      final int preferredVideoItag)
+            throws IOException, ExtractionException {
+        return getOrCreate(context, videoId, preferredVideoItag, null);
+    }
+
+    public static Holder getOrCreate(@NonNull final Context context,
+                                     @NonNull final String videoId,
+                                     final int preferredVideoItag,
+                                     @Nullable final YoutubeSabrInfo extractorInfo)
             throws IOException, ExtractionException {
         final String preferredAudioTrackId = PREFERRED_AUDIO.get(videoId);
         final Holder existing = SESSIONS.get(videoId);
@@ -261,7 +288,9 @@ public final class SabrSessionStore {
             }
             final Localization localization = new Localization("en", "US");
             final ContentCountry contentCountry = new ContentCountry("US");
-            final YoutubeSabrInfo info = YoutubeSabrProbeFetch(videoId, localization, contentCountry);
+            final YoutubeSabrInfo info = isUsableExtractorInfo(extractorInfo, videoId)
+                    ? extractorInfo
+                    : YoutubeSabrProbeFetch(videoId, localization, contentCountry);
             final YoutubeSabrFormat audioFormat = pickAudioFormat(info, preferredAudioTrackId);
             final YoutubeSabrFormat videoFormat = pickVideoFormat(info, preferredVideoItag);
             if (audioFormat == null || videoFormat == null) {
@@ -318,6 +347,15 @@ public final class SabrSessionStore {
         }
     }
 
+    private static boolean isUsableExtractorInfo(@Nullable final YoutubeSabrInfo info,
+                                                 @NonNull final String videoId) {
+        return info != null
+                && videoId.equals(info.getVideoId())
+                && info.getServerAbrStreamingUrl() != null
+                && !info.getServerAbrStreamingUrl().isEmpty()
+                && !info.getFormats().isEmpty();
+    }
+
     @NonNull
     private static YoutubeSabrInfo YoutubeSabrProbeFetch(@NonNull final String videoId,
                                                         @NonNull final Localization localization,
@@ -327,18 +365,11 @@ public final class SabrSessionStore {
                 videoId, YoutubeSabrClientProfile.WEB, localization, contentCountry);
     }
 
-    // Force AAC (mp4) audio instead of the "best" (Opus/webm). honestly: Opus/webm audio just does
-    // NOT work through this chunk pipeline. it under-supplies the audio renderer -> AudioTrack
-    // underruns -> constant rebuffering (hundreds vs ~2 on AAC, phone cooks). re-confirmed on media3
-    // 1.10 AFTER fixing the separate ~2min pump false-stall, so it's its own bug, not that one. i
-    // spent ~2h on it: ruled out fetch, cache, chunk timing, the media3 loading contract, buffer
-    // size... the data IS cached fine, so it's somewhere inside media3's Opus/webm extract->render
-    // with the way we chunk it, and i still have no fucking idea how to fix it. AAC (itag 140) is
-    // mp4, hardware-decoded, ~same bitrate (130 vs 136 kbps) and plays perfectly smooth. so: AAC
-    // until someone cracks the Opus path. (audio codec isn't user-facing, so this isn't a band-aid
-    // on a user setting, just an internal pick.) Prefer the plain AAC variant: YouTube can expose
-    // extra xtags variants (e.g. voice-boost) and DRC for the same itag; a tiny bitrate difference
-    // must not make gameplay/music sound compressed, warped, or volume-pumped.
+    // Force AAC (mp4) audio instead of the "best" Opus/webm stream. With the current chunked SABR
+    // pipeline, Opus/webm can under-supply the audio renderer and cause repeated rebuffering even
+    // when the segment data is cached correctly. Prefer the plain AAC variant: YouTube can expose
+    // extra xtags variants (for example voice-boost) and DRC for the same itag; a tiny bitrate
+    // difference must not make music or mixed content sound compressed, warped, or volume-pumped.
     private static YoutubeSabrFormat pickAudioFormat(@NonNull final YoutubeSabrInfo info,
                                                      @Nullable final String preferredTrackId) {
         YoutubeSabrFormat aac = null;
@@ -354,16 +385,6 @@ public final class SabrSessionStore {
             // the original-language preference below.
             if (preferredTrackId != null && !preferredTrackId.equals(f.getAudioTrackId())) {
                 continue;
-            }
-            if (DIAG_AUDIO) {
-                System.out.println("SABR-AUDIO candidate itag=" + f.getItag()
-                        + " trackId=" + f.getAudioTrackId()
-                        + " name=" + f.getAudioTrackDisplayName()
-                        + " default=" + f.isAudioDefault()
-                        + " original=" + f.isOriginalAudio()
-                        + " drc=" + f.isDrc()
-                        + " xtags=" + f.getXtags()
-                        + " bitrate=" + f.getBitrate());
             }
             if (aac == null) {
                 aac = f;
@@ -384,15 +405,6 @@ public final class SabrSessionStore {
             if (preferForTrack || preferForPlain || preferForDrc || preferForBitrate) {
                 aac = f;
             }
-        }
-        if (DIAG_AUDIO && aac != null) {
-            System.out.println("SABR-AUDIO chosen video=" + info.getVideoId()
-                    + " itag=" + aac.getItag()
-                    + " trackId=" + aac.getAudioTrackId()
-                    + " name=" + aac.getAudioTrackDisplayName()
-                    + " drc=" + aac.isDrc()
-                    + " xtags=" + aac.getXtags()
-                    + " original=" + aac.isOriginalAudio());
         }
         if (aac == null && preferredTrackId != null) {
             // The requested track has no mp4/AAC variant: fall back to the default original pick.
@@ -430,9 +442,18 @@ public final class SabrSessionStore {
 
     /** Evict a cached session, stopping its pump so the thread + buffers are released. */
     public static void evict(@NonNull final String videoId) {
+        evict(videoId, null);
+    }
+
+    private static void evict(@NonNull final String videoId,
+                              @Nullable final Holder expectedHolder) {
         final Holder holder;
         synchronized (SabrSessionStore.class) {
-            holder = SESSIONS.remove(videoId);
+            holder = SESSIONS.get(videoId);
+            if (holder == null || (expectedHolder != null && holder != expectedHolder)) {
+                return;
+            }
+            SESSIONS.remove(videoId);
             ORDER.remove(videoId);
         }
         if (holder != null) {

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrStreamPump.java
@@ -58,6 +58,7 @@ final class SabrStreamPump {
 
     private volatile boolean started;
     private volatile boolean stopped;
+    private volatile boolean clearCacheOnStop;
     private volatile boolean fatal;
     private volatile long lastReadMs;
     // Set by a reader blocked on an evicted segment behind the edge (backward seek); the loop
@@ -99,6 +100,7 @@ final class SabrStreamPump {
     void stop() {
         synchronized (this) {
             stopped = true;
+            clearCacheOnStop = true;
             // Don't self-interrupt: stop() is also reached from the pump thread itself via
             // evict-on-fatal, and setting our own interrupt flag could break a later blocking call.
             if (thread != null && thread != Thread.currentThread()) {
@@ -209,9 +211,17 @@ final class SabrStreamPump {
                     // Drop the dead session so a re-open rebuilds a fresh one (new token, new state).
                     SabrSessionStore.evict(holder.videoId);
                     break;
+                } catch (final OutOfMemoryError e) {
+                    Log.e(TAG, "SABR pump OOM; evicting session " + holder.videoId, e);
+                    fatal = true;
+                    SabrSessionStore.evict(holder.videoId);
+                    break;
                 }
             }
         } finally {
+            if (clearCacheOnStop) {
+                session.clearCache();
+            }
             synchronized (this) {
                 stopped = true;
             }

--- a/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
+++ b/app/src/main/java/org/schabi/newpipe/player/resolver/PlaybackResolver.java
@@ -60,6 +60,7 @@ import androidx.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
@@ -466,9 +467,11 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
         // hits the device VP9 decoder wall); audio-only playback passes 0 and keeps the best audio.
         final int preferredVideoItag =
                 (stream instanceof VideoStream) ? ((VideoStream) stream).getItag() : 0;
+        final YoutubeSabrInfo sabrInfo = getSabrInfo(stream);
         final SabrSessionStore.Holder holder;
         try {
-            holder = SabrSessionStore.getOrCreate(App.getApp(), videoId, preferredVideoItag);
+            holder = SabrSessionStore.getOrCreate(App.getApp(), videoId, preferredVideoItag,
+                    sabrInfo);
         } catch (final ExtractionException e) {
             throw new IOException("Could not start SABR session for " + videoId, e);
         }
@@ -482,6 +485,12 @@ public interface PlaybackResolver extends Resolver<StreamInfo, MediaSource> {
                 .setCustomCacheKey(cacheKey)
                 .build();
         return new SabrMediaSource(mediaItem, holder, new Localization("en", "US"));
+    }
+
+    @Nullable
+    private static YoutubeSabrInfo getSabrInfo(@NonNull final Stream stream) {
+        final Serializable info = stream.getDeliveryMethodInfo();
+        return info instanceof YoutubeSabrInfo ? (YoutubeSabrInfo) info : null;
     }
 
     /**

--- a/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/player/seekbarpreview/SeekbarPreviewThumbnailHolder.java
@@ -31,6 +31,8 @@ public class SeekbarPreviewThumbnailHolder {
     // https://stackoverflow.com/a/54744028
     public static final String TAG = "SeekbarPrevThumbHolder";
 
+    private static final int MAX_STORYBOARD_BITMAP_PAGES = 48;
+
     // Key = Position of the picture in milliseconds
     // Supplier = Supplies the bitmap for that position
     private final SparseArrayCompat<Supplier<Bitmap>> seekbarPreviewData =
@@ -108,13 +110,18 @@ public class SeekbarPreviewThumbnailHolder {
         Log.d(TAG, "Starting generation of seekbarPreviewData");
         final Stopwatch sw = Log.isLoggable(TAG, Log.DEBUG) ? Stopwatch.createStarted() : null;
 
-        int currentPosMs = 0;
-        int pos = 1;
-
         final int urlFrameCount = frameset.getFramesPerPageX() * frameset.getFramesPerPageY();
+        final List<String> urls = frameset.getUrls();
+        final int pageStep = Math.max(1,
+                (int) Math.ceil((double) urls.size() / MAX_STORYBOARD_BITMAP_PAGES));
+        if (pageStep > 1) {
+            Log.d(TAG, "Sampling seekbarPreviewData storyboards: pages=" + urls.size()
+                    + ", step=" + pageStep);
+        }
 
         // Process each url in the frameset
-        for (final String url : frameset.getUrls()) {
+        for (int pageIndex = 0; pageIndex < urls.size(); pageIndex += pageStep) {
+            final String url = urls.get(pageIndex);
             // get the bitmap
             final Bitmap srcBitMap = getBitMapFrom(url);
 
@@ -122,17 +129,20 @@ public class SeekbarPreviewThumbnailHolder {
             // concurrency and checks for "updateRequestIdentifier"
             final var generatedDataForUrl = new SparseArrayCompat<Supplier<Bitmap>>(urlFrameCount);
 
+            long currentPosMs = (long) pageIndex * urlFrameCount * frameset.getDurationPerFrame();
+            int pos = pageIndex * urlFrameCount + 1;
+
             // The bitmap consists of several images, which we process here
             // foreach frame in the returned bitmap
             for (int i = 0; i < urlFrameCount; i++) {
                 // Frames outside the video length are skipped
-                if (pos > frameset.getTotalCount()) {
+                if (pos > frameset.getTotalCount() || currentPosMs > Integer.MAX_VALUE) {
                     break;
                 }
 
                 // Get the bounds where the frame is found
                 final int[] bounds = frameset.getFrameBoundsAt(currentPosMs);
-                generatedDataForUrl.put(currentPosMs,
+                generatedDataForUrl.put((int) currentPosMs,
                                         createBitmapSupplier(srcBitMap, bounds, frameset));
 
                 currentPosMs += frameset.getDurationPerFrame();


### PR DESCRIPTION
Fixes https://github.com/InfinityLoop1308/PipePipe/issues/2577

Pairs with the extractor-side SABR init metadata fix: InfinityLoop1308/PipePipeExtractor#78

## Summary

SABR playback could still hit OOM or stall during long sessions / repeated switches.

This tightens the SABR playback lifecycle, makes init loading more deterministic, and caps long-video storyboard memory so the app does not keep growing toward the heap limit during extended playback.

## Problem

The previous SABR OOM fixes reduced the rapid-skip crash path, but long playback still showed high memory pressure.

There were multiple contributing paths:

- old SABR session caches could stay alive past the media source that needed them;
- failed/fatal SABR pump sessions could leave a dead holder around;
- init data could be coupled to the media pump path instead of Media3 initialization chunks;
- very long videos could load too many storyboard bitmap pages for seekbar preview.

On long videos this could push memory back toward the Android heap limit even when playback itself was still moving.

## Changes

- Tie SABR session cleanup to `MediaSource` references.
- Clear SABR session cache when the holder is actually released.
- Evict a SABR session if the pump hits OOM/fatal state.
- Cache fetched init data per holder.
- Fetch SABR init/index bytes directly from the extractor-provided initialization URL.
- Use a proper Media3 `InitializationChunk` before media chunks.
- Reuse the chunk extractor instead of recreating/prepending init data for every chunk.
- Cap storyboard bitmap page loading for very long videos.

## Validation

Build:

- `./gradlew :extractor:compileJava` in PipePipeExtractor.
- `./gradlew :app:assembleDebug -Px86` in PipePipeClient.
- `git diff --check` in both repos.

Long playback test on emulator:

- 10h YouTube video.
- 202 minutes monitored.
- Playback stayed `PLAYING(3)`.
- 0 app errors.
- 0 OOM.
- Max PSS: `459732 KB`.
- Final PSS: `410820 KB`.
- Chunks advanced to `3566`.

Log scan:

- no `OutOfMemoryError`.
- no `FATAL EXCEPTION`.
- no app ANR.
- no `ExoPlaybackException`.

After removing temporary debug logs and rebasing on current `upstream/dev`, the APK still builds successfully.

I could not rerun the final smoke after cleanup because `adb devices` no longer listed any connected emulator/device.

## Notes

This is focused on playback stability and memory lifetime. It builds on the current upstream download direction where downloads use HLS for now, while real SABR download support remains separate work.