### PR TITLE
fix(player): fix Android 17 lockscreen playback and SABR seek buffering

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
+++ b/app/src/main/java/org/schabi/newpipe/player/NotificationUtil.java
@@ -23,6 +23,7 @@ import org.schabi.newpipe.MainActivity;
 import org.schabi.newpipe.R;
 import org.schabi.newpipe.util.NavigationHelper;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 
 import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
@@ -54,6 +55,8 @@ public final class NotificationUtil {
 
     private NotificationManagerCompat notificationManager;
     private NotificationCompat.Builder notificationBuilder;
+    @Nullable
+    private WeakReference<Service> foregroundService;
 
     private NotificationUtil() {
     }
@@ -79,11 +82,16 @@ public final class NotificationUtil {
      */
     public synchronized void createNotificationIfNeededAndUpdate(final Player player,
                                                                  final boolean forceRecreate) {
+        final Service service = foregroundService == null ? null : foregroundService.get();
         if (forceRecreate || notificationBuilder == null) {
-            notificationBuilder = createNotification(player, null);
+            notificationBuilder = createNotification(player, service);
         }
         updateNotification(player);
-        notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+        if (service != null) {
+            startForeground(service, notificationBuilder);
+        } else {
+            notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build());
+        }
     }
 
     private synchronized NotificationCompat.Builder createNotification(final Player player, final Service service) {
@@ -192,16 +200,20 @@ public final class NotificationUtil {
 
 
     void createNotificationAndStartForeground(final Player player, final Service service) {
-        if (notificationBuilder == null) {
-            notificationBuilder = createNotification(player, service);
-        }
+        foregroundService = new WeakReference<>(service);
+        notificationBuilder = createNotification(player, service);
         updateNotification(player);
 
+        startForeground(service, notificationBuilder);
+    }
+
+    private void startForeground(final Service service,
+                                 final NotificationCompat.Builder builder) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            service.startForeground(NOTIFICATION_ID, notificationBuilder.build(),
+            service.startForeground(NOTIFICATION_ID, builder.build(),
                     ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
         } else {
-            service.startForeground(NOTIFICATION_ID, notificationBuilder.build());
+            service.startForeground(NOTIFICATION_ID, builder.build());
         }
     }
 
@@ -229,6 +241,7 @@ public final class NotificationUtil {
         }
         notificationManager = null;
         notificationBuilder = null;
+        foregroundService = null;
     }
 
 

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -968,6 +968,10 @@ public final class Player implements
         simpleExoPlayer.setVolume(isMuted ? 0 : 1);
         if (playQueue != null) {
             simpleExoPlayer.setShuffleModeEnabled(playQueue.isShuffled());
+            if (mediaSessionManager != null) {
+                mediaSessionManager.dispose();
+                mediaSessionManager = null;
+            }
             playerMediaSession = new PlayerMediaSession(this, simpleExoPlayer);
             mediaSessionManager = new MediaSessionManager(context, simpleExoPlayer,
                     playerMediaSession, service.getMediaSession(),

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrMediaPeriod.java
@@ -56,6 +56,8 @@ final class SabrMediaPeriod implements MediaPeriod,
     private SequenceableLoader compositeLoader = new EmptyLoader();
     @Nullable
     private MediaPeriod.Callback callback;
+    private boolean videoActive;
+    private boolean audioActive;
 
     SabrMediaPeriod(final SabrSessionStore.Holder holder,
                     final Format audioFormat,
@@ -123,14 +125,14 @@ final class SabrMediaPeriod implements MediaPeriod,
                 streamResetFlags[i] = true;
             }
         }
-        updateActiveTracks(selections);
+        updateActiveTracks(selections, positionUs);
         rebuildCompositeLoader();
         return positionUs;
     }
 
-    private void updateActiveTracks(final ExoTrackSelection[] selections) {
-        boolean videoActive = false;
-        boolean audioActive = false;
+    private void updateActiveTracks(final ExoTrackSelection[] selections, final long positionUs) {
+        boolean selectedVideo = false;
+        boolean selectedAudio = false;
         for (final ExoTrackSelection selection : selections) {
             if (selection == null) {
                 continue;
@@ -140,14 +142,17 @@ final class SabrMediaPeriod implements MediaPeriod,
                 continue;
             }
             if (trackTypes[groupIndex] == C.TRACK_TYPE_VIDEO) {
-                videoActive = true;
+                selectedVideo = true;
             } else if (trackTypes[groupIndex] == C.TRACK_TYPE_AUDIO) {
-                audioActive = true;
+                selectedAudio = true;
             }
         }
-        holder.setActiveTracks(videoActive, audioActive);
+        videoActive = selectedVideo;
+        audioActive = selectedAudio;
+        holder.prepareForPlaybackPositionMs(positionUs / 1000, selectedVideo, selectedAudio);
+        holder.setActiveTracks(selectedVideo, selectedAudio);
         Log.d(TAG, "activeTracks video=" + holder.videoId
-                + " video=" + videoActive + " audio=" + audioActive);
+                + " video=" + selectedVideo + " audio=" + selectedAudio);
     }
 
     private ChunkSampleStream<SabrChunkSource> buildStream(final ExoTrackSelection selection,
@@ -242,6 +247,7 @@ final class SabrMediaPeriod implements MediaPeriod,
 
     @Override
     public long seekToUs(final long positionUs) {
+        holder.prepareForPlaybackPositionMs(positionUs / 1000, videoActive, audioActive);
         for (final ChunkSampleStream<SabrChunkSource> s : streams) {
             s.seekToUs(positionUs);
         }

--- a/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
+++ b/app/src/main/java/org/schabi/newpipe/player/datasource/SabrSessionStore.java
@@ -119,6 +119,32 @@ public final class SabrSessionStore {
             }
         }
 
+        void prepareForPlaybackPositionMs(final long positionMs,
+                                          final boolean videoActive,
+                                          final boolean audioActive) {
+            if (positionMs <= 0 || (!videoActive && !audioActive)) {
+                return;
+            }
+            if (videoActive) {
+                final int sequence = session.getStreamState()
+                        .getSegmentNumberAtOrAfterTimeMs(videoFormat, positionMs);
+                final long segmentStartMs = session.getStreamState()
+                        .getSegmentStartMs(videoFormat, sequence);
+                setReaderPositionMs(videoFormat.getItag(), segmentStartMs);
+                session.prepareForForwardJump(SabrSegmentRequest.media(videoFormat, sequence));
+            }
+            if (audioActive) {
+                final int sequence = session.getStreamState()
+                        .getSegmentNumberAtOrAfterTimeMs(audioFormat, positionMs);
+                final long segmentStartMs = session.getStreamState()
+                        .getSegmentStartMs(audioFormat, sequence);
+                setReaderPositionMs(audioFormat.getItag(), segmentStartMs);
+                if (!videoActive) {
+                    session.prepareForForwardJump(SabrSegmentRequest.media(audioFormat, sequence));
+                }
+            }
+        }
+
         private boolean hasActiveTracks() {
             return !activeReaderItags.isEmpty();
         }


### PR DESCRIPTION
Fixes https://github.com/InfinityLoop1308/PipePipe/issues/2575

Pairs with the extractor-side SABR cold-start fix: https://github.com/InfinityLoop1308/PipePipeExtractor/pull/80

## Summary

I reproduced the lockscreen/background issue on my Pixel 8 / Android 17.

There were two problems here:

- Android 17 could lose the proper foreground/media playback state after notification updates.
- SABR could keep an old reader position after a lockscreen MediaSession seek, so seeking forward could leave the player buffering forever.

## Problem

After `startForeground()`, later notification updates could go through `notify()` instead of keeping the service foreground notification updated through `startForeground()`.

For SABR, lockscreen seek can call `seekToUs()` without a new track selection. That means ExoPlayer starts asking for the new segment, but SABR was still pacing from the previous reader position.

Observed during repro:

```text
MediaSession seek -> position around 296s
SABR waiting for a later audio segment
readerHead still around the old position
player stuck in BUFFERING
```

## Changes

- Keep notification updates tied to `startForeground()` while the player service is alive.
- Dispose a stale media session before creating a new one.
- Track the currently active SABR audio/video tracks in `SabrMediaPeriod`.
- Prepare the SABR session position from `seekToUs()`, not only from track selection.

## Validation

Tested on Pixel 8 / Android 17:

- foreground playback
- background audio
- lockscreen play/pause
- lockscreen seek backward
- lockscreen seek forward
- queue transition after lockscreen seek

Build:

- `./gradlew :app:assembleDebug`
- `git diff --check`