### PR TITLE
Fix: Blocked channels accessible via click navigation

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/BaseListFragment.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -40,8 +41,10 @@ import org.schabi.newpipe.util.ThemeHelper;
 import org.schabi.newpipe.views.SuperScrollLayoutManager;
 
 import javax.annotation.Nonnull;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
@@ -278,6 +281,12 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             @Override
             public void selected(final ChannelInfoItem selectedItem) {
                 try {
+                    if (isChannelBlocked(selectedItem.getName())) {
+                        Toast.makeText(requireContext(),
+                                R.string.channel_is_blocked,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
                     onItemSelected(selectedItem);
                     NavigationHelper.openChannelFragment(getFM(),
                             selectedItem.getServiceId(),
@@ -294,6 +303,12 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
             @Override
             public void selected(final PlaylistInfoItem selectedItem) {
                 try {
+                    if (isChannelBlocked(selectedItem.getUploaderName())) {
+                        Toast.makeText(requireContext(),
+                                R.string.channel_is_blocked,
+                                Toast.LENGTH_SHORT).show();
+                        return;
+                    }
                     onItemSelected(selectedItem);
                     NavigationHelper.openPlaylistFragment(getFM(),
                             selectedItem.getServiceId(),
@@ -541,5 +556,22 @@ public abstract class BaseListFragment<I, N> extends BaseStateFragment<I>
      */
     protected ItemViewMode getItemViewMode() {
         return ThemeHelper.getItemViewMode(requireContext());
+    }
+
+    /**
+     * Check if a channel name is in the user's block list.
+     * @param channelName the channel name to check
+     * @return true if the channel is blocked
+     */
+    protected boolean isChannelBlocked(@Nullable final String channelName) {
+        if (channelName == null || channelName.isEmpty()) {
+            return false;
+        }
+        final SharedPreferences prefs = PreferenceManager
+                .getDefaultSharedPreferences(requireContext());
+        final Set<String> blockedChannels = prefs.getStringSet(
+                getString(R.string.filter_by_channel_key) + "_set",
+                new HashSet<>());
+        return blockedChannels.contains(channelName);
     }
 }

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/channel/ChannelFragment.java
@@ -11,6 +11,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,8 +40,10 @@ import org.schabi.newpipe.util.NavigationHelper;
 import org.schabi.newpipe.util.StateSaver;
 import org.schabi.newpipe.util.external_communication.ShareUtils;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.core.Observable;
@@ -396,6 +399,26 @@ public class ChannelFragment extends BaseStateFragment<ChannelInfo>
     @Override
     public void handleResult(@NonNull final ChannelInfo result) {
         super.handleResult(result);
+
+        // Safety net: if the channel is in the block list, prevent access
+        final String channelName = result.getName();
+        if (channelName != null && !channelName.isEmpty()) {
+            final SharedPreferences prefs = PreferenceManager
+                    .getDefaultSharedPreferences(requireContext());
+            final Set<String> blockedChannels = prefs.getStringSet(
+                    getString(R.string.filter_by_channel_key) + "_set",
+                    new HashSet<>());
+            if (blockedChannels.contains(channelName)) {
+                Toast.makeText(requireContext(),
+                        R.string.channel_is_blocked,
+                        Toast.LENGTH_SHORT).show();
+                if (getParentFragmentManager().getBackStackEntryCount() > 0) {
+                    getParentFragmentManager().popBackStack();
+                }
+                return;
+            }
+        }
+
         currentInfo = result;
         setInitialData(result.getServiceId(), result.getOriginalUrl(), result.getName());
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -954,6 +954,7 @@
 <string name="search_result">Search results</string>
 <string name="filter_field_summary">Apply Filter To</string>
 <string name="channel_videos">Channel videos</string>
+<string name="channel_is_blocked">This channel is in your block list</string>
 <string name="success">Success</string>
 <string name="settings_category_proxy_title">Proxy (Supporters)</string>
 <string name="proxy_token_title">Token</string>


### PR DESCRIPTION
## Bug
If a user manages to click a blocked channel's icon/name or a playlist from a blocked channel, the app navigates to the channel/playlist page, bypassing the content filter.

## Fix
- Added click navigation guards in `BaseListFragment` that check if the target channel is blocked. If so, it shows a Toast ("This channel is in your block list") and prevents opening the fragment.
- Added a safety net guard in `ChannelFragment.handleResult()` so if a blocked channel page is loaded (e.g. from deep links), it shows the Toast and immediately pops the fragment backstack.
- Added a new string resource `channel_is_blocked` for the Toast message.