### PR TITLE
fix: fullscreen button did nothing in portrait on large screens

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -263,8 +263,10 @@ public final class VideoDetailFragment
             // let's make the video in fullscreen again
             checkLandscape();
         } else if (player.isFullscreen() && !player.isVerticalVideo()
-                // Tablet UI has orientation-independent fullscreen
-                && !DeviceUtils.isTablet(activity)) {
+                // Tablet UI has orientation-independent fullscreen,
+                // large screens can't be rotated programmatically anyway
+                && !DeviceUtils.isTablet(activity)
+                && !DeviceUtils.isOrientationRequestIgnored(activity)) {
             // Device is in portrait orientation after rotation but UI is in fullscreen.
             // Return back to non-fullscreen state
             player.toggleFullscreen();
@@ -2286,13 +2288,17 @@ public final class VideoDetailFragment
         final boolean isTablet    = DeviceUtils.isTablet(activity);
         final boolean autoLocked  = globalScreenOrientationLocked(activity);
 
-        // 1. 平板且（系统可自动旋转 或 当前已横），直接切播放器全屏/非全屏
-        if (isTablet && (!autoLocked || isLandscape)) {
+        // 1. Tablet with auto-rotate enabled (or already in landscape): toggle player
+        // fullscreen directly. On large screens (sw >= 600dp, e.g. unfolded foldables)
+        // the system ignores setRequestedOrientation(), so rotating programmatically
+        // is impossible — toggle fullscreen directly there as well
+        if (isTablet && (!autoLocked || isLandscape)
+                || DeviceUtils.isOrientationRequestIgnored(requireContext())) {
             player.toggleFullscreen();
             return;
         }
 
-        // 2. 手机 or 平板但系统锁定了自动旋转，就去真正设置屏幕方向
+        // 2. Phone (or tablet with auto-rotate locked): actually change screen orientation
         if (!autoLocked) {
             if (isLandscape) {
                 player.toggleFullscreen();
@@ -2300,7 +2306,7 @@ public final class VideoDetailFragment
                 activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
             }
         } else {
-            // 系统锁定时，再用“强制模式”来切
+            // Auto-rotate is locked, force the orientation change
             activity.setRequestedOrientation(
                     isLandscape
                             ? ActivityInfo.SCREEN_ORIENTATION_PORTRAIT

--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -5002,6 +5002,9 @@ case ERROR_CODE_DECODER_INIT_FAILED: {
                 && service.isLandscape() == isVerticalVideo
                 && !DeviceUtils.isTv(context)
                 && !DeviceUtils.isTablet(context)
+                // can't rotate large screens programmatically, and with the
+                // fallback to toggleFullscreen() this would exit fullscreen
+                && !DeviceUtils.isOrientationRequestIgnored(context)
                 && fragmentListener != null) {
             // set correct orientation
             fragmentListener.onScreenRotationButtonClicked();

--- a/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
+++ b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java
@@ -170,6 +170,19 @@ public final class DeviceUtils {
                 & Configuration.SCREENLAYOUT_SIZE_MASK) >= Configuration.SCREENLAYOUT_SIZE_LARGE;
     }
 
+    /**
+     * Whether the system ignores {@link android.app.Activity#setRequestedOrientation(int)}.
+     *
+     * <p>Since Android 12L, devices with a display at least 600dp wide (tablets, unfolded
+     * foldables) may ignore fixed-orientation requests; since Android 16 with targetSdk 36
+     * this is guaranteed. On such screens fullscreen has to be toggled without trying to
+     * change the screen orientation.</p>
+     */
+    public static boolean isOrientationRequestIgnored(@NonNull final Context context) {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2
+                && context.getResources().getConfiguration().smallestScreenWidthDp >= 600;
+    }
+
     public static boolean isConfirmKey(final int keyCode) {
         switch (keyCode) {
             case KeyEvent.KEYCODE_DPAD_CENTER:


### PR DESCRIPTION
<!-- Note: the code links pointing to 4in4in/PipePipeClient work after the
     fix/fullscreen-large-screens branch is pushed to the fork. -->

## Summary

On large screens (unfolded foldables, tablets) the player's fullscreen button did nothing in portrait orientation — it only started working after physically rotating the device to landscape. Reproduced on a Galaxy Fold 6 (inner screen), both with tablet mode enabled and disabled.

## Problem

The fullscreen button handler ([`VideoDetailFragment.onScreenRotationButtonClicked()`](https://github.com/InfinityLoop1308/PipePipeClient/blob/da70c51c71a20211821768d06b25aa62b525434c/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L2284-L2310)) only toggles fullscreen directly on tablets when auto-rotate is enabled or the device is already in landscape. In every other case it calls [`activity.setRequestedOrientation(SENSOR_LANDSCAPE)`](https://github.com/InfinityLoop1308/PipePipeClient/blob/da70c51c71a20211821768d06b25aa62b525434c/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L2296-L2309) and relies on the resulting rotation to enter fullscreen.

Since Android 12L, device manufacturers can configure devices to ignore `setRequestedOrientation()` on large screens (see [Device compatibility mode](https://developer.android.com/guide/practices/device-compatibility-mode)); Samsung enables this on the Fold's inner display. And since Android 16, for apps targeting SDK 36 this is guaranteed platform behavior on displays with smallest width >= 600dp: orientation restrictions, including `setRequestedOrientation()`, [are ignored](https://developer.android.com/about/versions/16/behavior-changes-16#ignore-orientation-resizability-and-aspect-ratio-restrictions) (also announced in the [Android Developers blog](https://android-developers.googleblog.com/2025/01/orientation-and-resizability-changes-in-android-16.html)). PipePipe [targets SDK 36](https://github.com/InfinityLoop1308/PipePipeClient/blob/da70c51c71a20211821768d06b25aa62b525434c/app/build.gradle#L25), so on the unfolded Fold the call is silently ignored, without any error, and the button appears dead:

- tablet mode, portrait, system auto-rotate off → rotation request ignored → nothing happens;
- tablet mode off, portrait → same phone code path → same result;
- landscape works, because there the tablet branch toggles fullscreen directly.

## Changes

- Add [`DeviceUtils.isOrientationRequestIgnored()`](https://github.com/4in4in/PipePipeClient/blob/da756869a9672c77f1a30443aebe4cf399b17d7b/app/src/main/java/org/schabi/newpipe/util/DeviceUtils.java#L173-L185): Android 12L+ and current display at least sw600dp — the same threshold the system uses when ignoring orientation requests.
- [`onScreenRotationButtonClicked()`](https://github.com/4in4in/PipePipeClient/blob/da756869a9672c77f1a30443aebe4cf399b17d7b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L2286-L2299): on such screens toggle fullscreen directly instead of trying to rotate (portrait fullscreen is already supported — vertical videos use it).
- Skip two auto-exit-fullscreen paths that rely on forced rotation and would otherwise kick these devices out of portrait fullscreen: [`VideoDetailFragment.onServiceConnected()`](https://github.com/4in4in/PipePipeClient/blob/da756869a9672c77f1a30443aebe4cf399b17d7b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java#L265-L272) and [`Player.onVideoSizeChanged()`](https://github.com/4in4in/PipePipeClient/blob/da756869a9672c77f1a30443aebe4cf399b17d7b/app/src/main/java/org/schabi/newpipe/player/Player.java#L5000-L5011).
- Translate the Chinese comments in the touched handler to English.

Phones and pre-12L tablets keep the existing behavior (the new check returns false there); the folded cover screen (below sw600dp) also behaves as before.

## Validation

- `./gradlew assembleDebug` in PipePipeClient.
- Tested on a real Galaxy Fold 6:
  - unfolded, portrait, system auto-rotate off, tablet mode auto and off → the button now enters/exits fullscreen;
  - unfolded, landscape → unchanged;
  - cover screen (phone layout) → unchanged, the button still rotates to landscape.
