### PR TITLE
Add option to filter livestreams from the feed

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
+++ b/app/src/main/java/org/schabi/newpipe/local/feed/service/FeedLoadManager.kt
@@ -26,6 +26,7 @@ import org.schabi.newpipe.util.ChannelTabHelper
 import org.schabi.newpipe.util.ExtractorHelper.getChannelInfo
 import org.schabi.newpipe.util.ExtractorHelper.getChannelTab
 import org.schabi.newpipe.util.ExtractorHelper.getMoreChannelTabItems
+import org.schabi.newpipe.util.StreamTypeUtil
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.util.concurrent.ConcurrentHashMap
@@ -80,6 +81,11 @@ class FeedLoadManager(private val context: Context) {
         val filterFutureItems = defaultSharedPreferences.getBoolean(
             context.getString(R.string.filter_future_items_key),
             true
+        )
+
+        val filterLivestreams = defaultSharedPreferences.getBoolean(
+            context.getString(R.string.filter_livestreams_key),
+            false
         )
 
         val outdatedThreshold = if (ignoreOutdatedThreshold) {
@@ -214,7 +220,7 @@ class FeedLoadManager(private val context: Context) {
                                         }
                                         .filterIsInstance<StreamInfoItem>()
                                 }
-                                streams = streams?.filterNot { it.isRoundPlayStream || (filterFutureItems && it.uploadDate != null && it.uploadDate!!.offsetDateTime().isAfter(OffsetDateTime.now())) }
+                                streams = streams?.filterNot { it.isRoundPlayStream || (filterFutureItems && it.uploadDate != null && it.uploadDate!!.offsetDateTime().isAfter(OffsetDateTime.now())) || (filterLivestreams && StreamTypeUtil.isLiveStream(it.streamType)) }
 
                                 return@defer Flowable.just(
                                     FeedUpdateInfo(

--- a/app/src/main/java/org/schabi/newpipe/settings/FilterSettingsFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/settings/FilterSettingsFragment.java
@@ -18,6 +18,7 @@ public class FilterSettingsFragment extends BasePreferenceFragment {
         Preference filter_shorts = findPreference(getString(R.string.filter_shorts_key));
         Preference filter_paid_contents = findPreference(getString(R.string.filter_paid_contents_key));
         Preference filter_future_items = findPreference(getString(R.string.filter_future_items_key));
+        Preference filter_livestreams = findPreference(getString(R.string.filter_livestreams_key));
         Preference filter_type = findPreference(getString(R.string.filter_type_key));
 
         filter_by_keyword.setOnPreferenceClickListener(preference -> {
@@ -47,6 +48,13 @@ public class FilterSettingsFragment extends BasePreferenceFragment {
         });
 
         filter_future_items.setOnPreferenceChangeListener((preference, newValue) -> {
+            new Handler().postDelayed(() -> {
+                ServiceHelper.initServices(getContext());
+            }, 100);
+            return true;
+        });
+
+        filter_livestreams.setOnPreferenceChangeListener((preference, newValue) -> {
             new Handler().postDelayed(() -> {
                 ServiceHelper.initServices(getContext());
             }, 100);

--- a/app/src/main/res/values/settings_keys.xml
+++ b/app/src/main/res/values/settings_keys.xml
@@ -1726,6 +1726,7 @@
         <item>@string/description_tab_description</item>
     </string-array>
     <string name="filter_future_items_key">filter_future_items_key</string>
+    <string name="filter_livestreams_key">filter_livestreams_key</string>
     <string name="use_experimental_new_ui_key">use_experimental_new_ui</string>
     <string name="force_end_on_overtime_key">force_end_on_overtime</string>
     <string name="use_old_search_filter_key">use_old_search_filter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1038,6 +1038,8 @@
 <string name="video_tabs_summary">Configure which tabs to show on video detail screen</string>
 <string name="filter_future_items_title">Filter future items</string>
 <string name="filter_future_items_summary">Remove items scheduled for a future release</string>
+<string name="filter_livestreams_title">Filter livestreams</string>
+<string name="filter_livestreams_summary">Remove livestreams from the feed</string>
 <string name="pin_video_to_top_title">Pin video to top</string>
 <string name="pin_video_to_top_summary">Keep the video pinned to the top while scrolling the video detail page</string>
 <string name="settings_category_behavior_title">Behavior</string>

--- a/app/src/main/res/xml/filter_settings.xml
+++ b/app/src/main/res/xml/filter_settings.xml
@@ -35,6 +35,13 @@
             android:title="@string/filter_future_items_title"
             app:singleLineTitle="false"
             app:iconSpaceReserved="false" />
+    <SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/filter_livestreams_key"
+            android:summary="@string/filter_livestreams_summary"
+            android:title="@string/filter_livestreams_title"
+            app:singleLineTitle="false"
+            app:iconSpaceReserved="false" />
     <MultiSelectListPreference
             android:key="@string/filter_type_key"
             android:title="@string/filter_field_summary"


### PR DESCRIPTION
## Objective

Add an option to hide livestreams from the subscriptions feed, alongside the other content filters.

## Behavior

A new "Filter livestreams" switch is added to the content filter settings (next to "Filter future items"). When enabled, livestreams (`LIVE_STREAM` and `AUDIO_LIVE_STREAM`) are removed from the feed. Disabled by default, so existing behavior is unchanged.

## Changes

- `filter_settings.xml`: new `SwitchPreference` for `filter_livestreams_key`.
- `settings_keys.xml` / `strings.xml`: new preference key, title and summary.
- `FilterSettingsFragment.java`: wire the new preference (same pattern as the other filters).
- `FeedLoadManager.kt`: read the preference and, when enabled, filter out livestreams during feed load, using the existing `StreamTypeUtil.isLiveStream(...)` helper and the same `filterNot` pipeline as the future-items filter.

## Notes

Applied at feed load time, consistent with the existing "Filter future items" filter.
