### PR TITLE
fix: crash when opening a new video on media tunneling devices (ex: FireTV)

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/player/Player.java
+++ b/app/src/main/java/org/schabi/newpipe/player/Player.java
@@ -5617,7 +5617,7 @@ case ERROR_CODE_DECODER_INIT_FAILED: {
         cleanupVideoSurface();
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) { // >=API23
-            surfaceHolderCallback = new SurfaceHolderCallback(context, simpleExoPlayer);
+            surfaceHolderCallback = new SurfaceHolderCallback(simpleExoPlayer);
             binding.surfaceView.getHolder().addCallback(surfaceHolderCallback);
             final Surface surface = binding.surfaceView.getHolder().getSurface();
             // ensure player is using an unreleased surface, which the surfaceView might not be
@@ -5638,7 +5638,6 @@ case ERROR_CODE_DECODER_INIT_FAILED: {
             if (binding != null) {
                 binding.surfaceView.getHolder().removeCallback(surfaceHolderCallback);
             }
-            surfaceHolderCallback.release();
             surfaceHolderCallback = null;
         }
     }

--- a/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
+++ b/app/src/main/java/org/schabi/newpipe/player/playback/SurfaceHolderCallback.java
@@ -1,10 +1,8 @@
 package org.schabi.newpipe.player.playback;
 
-import android.content.Context;
 import android.view.SurfaceHolder;
 
 import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.video.PlaceholderSurface;
 
 /**
  * Prevent error message: 'Unrecoverable player error occurred'
@@ -12,7 +10,7 @@ import com.google.android.exoplayer2.video.PlaceholderSurface;
  * having a Callback that handles the lifecycle of the surface.
  * <p>
  * How?: In case we are no longer able to write to the surface eg. through rotation/putting in
- * background we set set a DummySurface. Although it it works on API >= 23 only.
+ * background we clear the surface, and the player swaps in a placeholder one of its own.
  * Result: we get a little video interruption (audio is still fine) but we won't get the
  * 'Unrecoverable player error occurred' error message.
  * <p>
@@ -24,12 +22,9 @@ import com.google.android.exoplayer2.video.PlaceholderSurface;
  */
 public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
-    private final Context context;
     private final Player player;
-    private PlaceholderSurface placeholderSurface;
 
-    public SurfaceHolderCallback(final Context context, final Player player) {
-        this.context = context;
+    public SurfaceHolderCallback(final Player player) {
         this.player = player;
     }
 
@@ -47,16 +42,6 @@ public final class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
     @Override
     public void surfaceDestroyed(final SurfaceHolder holder) {
-        if (placeholderSurface == null) {
-            placeholderSurface = PlaceholderSurface.newInstanceV17(context, false);
-        }
-        player.setVideoSurface(placeholderSurface);
-    }
-
-    public void release() {
-        if (placeholderSurface != null) {
-            placeholderSurface.release();
-            placeholderSurface = null;
-        }
+        player.setVideoSurface(null);
     }
 }


### PR DESCRIPTION
## Problem

On a device using media tunneling, playing a video and then opening another one
crashes the app. Reproduced 100% of the time on a Fire TV Stick 4K (`AFTMM` /
`mantis`, MediaTek MT8695, Fire OS 6 / API 25) playing tunneled VP9. Phones do
not reproduce it, because they rarely get a tunneled decoder for these streams.

## Root cause

`SurfaceHolderCallback.surfaceDestroyed()` created a `PlaceholderSurface` of its
own and handed it to the player. That dates from an ExoPlayer 2.x workaround
(google/ExoPlayer#2703, 2017), written when the player did not manage placeholder
surfaces itself.

The player does that itself now, and it checks first whether swapping the
surface is even possible:

```java
// MediaCodecVideoRenderer, media3 1.10.1
protected boolean shouldUsePlaceholderSurface(MediaCodecInfo codecInfo) {
  return !tunneling
      && !codecNeedsSetOutputSurfaceWorkaround(codecInfo.name)
      && (!codecInfo.secure || PlaceholderSurface.isSecureSupported(context));
}
```

The `!tunneling` term is the one that matters here. `MediaCodec.setOutputSurface()`
cannot change the surface of a tunneled codec, and ACodec rejects the attempt. 
When `setOutput()` finds no usable surface it takes the other branch
and calls `releaseCodec(); maybeInitCodecOrBypass();` instead, which works.

Passing our own placeholder made that check unreachable. `displaySurface` was
never null, so the renderer always took the swap path:

```
W ACodec  : cannot change tunneled surface
E ExoPlayerImplInternal: Playback error
  Caused by: java.lang.IllegalStateException
      at android.media.MediaCodec.native_setSurface(Native Method)
      at MediaCodecVideoRenderer.setOutputSurfaceV23(MediaCodecVideoRenderer.java:2534)
      at ExoPlayerImplInternal.setVideoOutputInternal(ExoPlayerImplInternal.java:1943)
```

The exception escapes `handleMessage`, so the `PlayerMessage` is never marked
delivered. `ExoPlayerImpl.setVideoOutputInternal()` blocks the main thread in
`blockUntilDelivered()` until the detach timeout expires (two seconds), then
raises the timeout as a playback error:

```
E Player  : ExoPlaybackException: Unexpected runtime error
  Caused by: ExoTimeoutException: Detaching surface timed out.
      at ExoPlayerImpl.setVideoOutputInternal(ExoPlayerImpl.java:2988)
      at SurfaceHolderCallback.surfaceDestroyed(SurfaceHolderCallback.java:53)
      at android.view.SurfaceView.updateWindow(SurfaceView.java:588)
      at android.view.ViewGroup.removeView(ViewGroup.java:4620)
      at PlayerService.removeViewFromParent(PlayerService.java:254)
      at VideoDetailFragment.hideMainPlayerOnLoadingNewStream(VideoDetailFragment.java:1469)
```

The error is delivered synchronously, which puts `onPlayerError` inside the
`ViewGroup.removeView()` whose detach pass called `surfaceDestroyed` in the first
place. `VideoDetailFragment.onPlayerError()` then calls
`hideMainPlayerOnLoadingNewStream()` again, re-entering `removeViewFromParent()`
while the outer removal is still running. `ViewGroup.removeView()` resolves the child index up front and only writes through it later in `removeFromArray()`, so the nested removal shrinks the array underneath it and
the outer call dereferences an emptied slot.

The crash comes from that nested removal. On API 25 it can also surface one frame
earlier, in `SurfaceView.updateWindow()`, which dereferences its
`IWindowSession` with no null check before API 26 rewrote the class.

## Fix

Pass `null` so the renderer makes the decision itself. It substitutes its own
placeholder when that is safe, and releases the codec when it is not.

Behaviour is unchanged for non-tunneled codecs: the renderer allocates the same
`PlaceholderSurface` we used to allocate here. The rest of the diff is the now
dead plumbing coming out (the field, its lazy init, `release()` and its call
site, two imports), plus a Javadoc line that no longer described the code.

## Testing

Fire TV Stick 4K, API 25, tunneled VP9. Four consecutive videos, four clean
codec cycles:

```
08:59:40  setting surface generation 22809601   Configuring TUNNELED video playback
09:00:09    MtkOmxVdec::ComponentDeInit                   codec released, not re-pointed
09:00:25  setting surface generation 22809602   Configuring TUNNELED video playback
09:01:14    MtkOmxVdec::ComponentDeInit
09:01:15  setting surface generation 22809603   Configuring TUNNELED video playback
09:01:43    MtkOmxVdec::ComponentDeInit
09:01:45  setting surface generation 22809604   Configuring TUNNELED video playback
```

Tunneling stays enabled, so no hardware A/V sync is lost. `cannot change
tunneled surface`, `Detaching surface timed out`, `onPlayerError`,
`NullPointerException`, `IllegalStateException` and `FATAL` are all absent from
the log. The two second main thread stall at each transition is gone as well:
before the fix it landed squarely on the video switch, and now the only
`Choreographer: Skipped frames` events are at stream start.

Phone (arm64, non-tunneled) checked for regressions in the paths the original
workaround existed for: rotation during playback, background and return, and
fullscreen toggle. No change in behaviour, and no `Unrecoverable player error
occurred`.

## Notes

This is not specific to Fire TV. Any device that ends up with a tunneled decoder
is affected, which on Android TV is common. Users hitting it today can work
around it with the existing "Disable media tunneling" preference, at the cost of
tunneled playback.