### PR TITLE
Make the video title expand when it is tapped once

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -454,7 +454,7 @@ public final class VideoDetailFragment
         // so I have to remove the cleanup
        // bottomSheetBehavior.setBottomSheetCallback(null);
 
-        if (activity.isFinishing()) {
+         if (activity.isFinishing()) {
             playQueue = null;
             currentInfo = null;
             stack = new LinkedList<>();
@@ -598,7 +598,9 @@ public final class VideoDetailFragment
                 player.setRecovery();
             }
             openVideoPlayerAutoFullscreen();
-        } else if (id == R.id.detail_toggle_secondary_controls_view) {
+        } else if (id == R.id.detail_video_title_view
+                || id == R.id.detail_title_root_layout
+                || id == R.id.detail_toggle_secondary_controls_view) {
             toggleTitleAndSecondaryControls();
         } else if (id == R.id.overlay_thumbnail || id == R.id.overlay_metadata_layout || id == R.id.overlay_buttons_layout) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
@@ -658,7 +660,7 @@ public final class VideoDetailFragment
             } else {
                 openChannel(currentInfo.getUploaderUrl(), currentInfo.getUploaderName());
             }
-        } else if (id == R.id.detail_video_title_view) {
+        } else if (id == R.id.detail_video_title_view || id == R.id.detail_title_root_layout) {
             ShareUtils.copyToClipboard(requireContext(),
                     binding.detailVideoTitleView.getText().toString());
         } else if (id == R.id.detail_toggle_secondary_controls_view) {
@@ -762,8 +764,8 @@ public final class VideoDetailFragment
     protected void initListeners() {
         super.initListeners();
 
-        binding.detailVideoTitleView.setOnClickListener(this);
-        binding.detailVideoTitleView.setOnLongClickListener(this);
+        binding.detailTitleRootLayout.setOnClickListener(this);
+        binding.detailTitleRootLayout.setOnLongClickListener(this);
         binding.detailToggleSecondaryControlsView.setOnClickListener(this);
         binding.detailToggleSecondaryControlsView.setOnLongClickListener(this);
         binding.detailUploaderRootLayout.setOnClickListener(this);

--- a/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/detail/VideoDetailFragment.java
@@ -454,7 +454,7 @@ public final class VideoDetailFragment
         // so I have to remove the cleanup
        // bottomSheetBehavior.setBottomSheetCallback(null);
 
-         if (activity.isFinishing()) {
+        if (activity.isFinishing()) {
             playQueue = null;
             currentInfo = null;
             stack = new LinkedList<>();


### PR DESCRIPTION
In the app it is very hard to use the small arrow next the video title.
This PR makes the video title expand with only one click, similar to the small arrow but also keeping the small arrow function.

This is done by moving the click/long-click listeners from the title TextView onto its parent container (`detail_title_root_layout`), which already spans the full width of the row

This also fixes the row's press-state ripple/highlight (selectableItemBackground) so it now correctly covers the entire row edge-to-edge, instead of only appearing when tapping in the far right edge of the arrow.

**Before**

https://github.com/user-attachments/assets/86d014d9-5e57-47fe-817b-72ae2525b1bb

**After**

https://github.com/user-attachments/assets/1956c676-2cb5-44ba-afcc-5e48e7a44245