### PR TITLE
fix: search history entry randomly not saved or moved to top

### DIFF
--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -1004,6 +1004,10 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         showMetaInfoInTextView(null, searchBinding.searchMetaInfoTextView,
                 searchBinding.searchMetaInfoSeparator, disposables);
         hideKeyboardSearch();
+        suggestionPublisher.onNext(theSearchString);
+        startLoading(false);
+        // Must be subscribed after startLoading(): it calls disposables.clear(), which would
+        // cancel the history write before it even reached the IO thread.
         disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(
@@ -1011,8 +1015,6 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
                         throwable -> showSnackBarError(new ErrorInfo(throwable, UserAction.SEARCHED,
                                 theSearchString, serviceId))
                 ));
-        suggestionPublisher.onNext(theSearchString);
-        startLoading(false);
     }
 
     @Override

--- a/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
+++ b/app/src/main/java/org/schabi/newpipe/fragments/list/search/SearchFragment.java
@@ -1004,17 +1004,16 @@ public class SearchFragment extends BaseListFragment<SearchInfo, ListExtractor.I
         showMetaInfoInTextView(null, searchBinding.searchMetaInfoTextView,
                 searchBinding.searchMetaInfoSeparator, disposables);
         hideKeyboardSearch();
+        // Fire-and-forget: deliberately not added to `disposables`, which is cleared by
+        // startLoading(), onPause() and onDestroy() and would cancel the history write
+        // before it even reached the IO thread.
+        historyRecordManager.onSearched(serviceId, theSearchString)
+                .doOnError(throwable -> Log.e(TAG,
+                        "Failed to save search history for \"" + theSearchString + "\"", throwable))
+                .onErrorComplete()
+                .subscribe();
         suggestionPublisher.onNext(theSearchString);
         startLoading(false);
-        // Must be subscribed after startLoading(): it calls disposables.clear(), which would
-        // cancel the history write before it even reached the IO thread.
-        disposables.add(historyRecordManager.onSearched(serviceId, theSearchString)
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe(
-                        ignored -> { },
-                        throwable -> showSnackBarError(new ErrorInfo(throwable, UserAction.SEARCHED,
-                                theSearchString, serviceId))
-                ));
     }
 
     @Override


### PR DESCRIPTION
## Fix search history entry randomly not saved or moved to top

### Problem
The search history write in `SearchFragment.search()` was subscribed into the
view-lifecycle `disposables` set. That set is cleared by `startLoading()`,
`onPause()` and `onDestroy()`. If the IO scheduler had not yet picked up the
write when any of those ran, the `Maybe` was disposed and `runInTransaction`
never executed. The query was silently not inserted or not moved to the top.

### Fix
Subscribe to `historyRecordManager.onSearched()` fire-and-forget, without
adding it to `disposables`, so no lifecycle event can cancel it. Errors are
logged instead of shown in a snackbar, since the fragment may already be gone.
This mirrors how `Player.registerStreamViewed()` records views.

### Testing
- `compileDebugJavaWithJavac` passes.
- Installed the debug build on a device (see attached videos below)